### PR TITLE
Resolve symlinks for app:///[...] and file:///[...] URLs on Windows

### DIFF
--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -2,6 +2,7 @@
 
 #include <UrlLib/UrlLib.h>
 #include <arcana/threading/cancellation.h>
+#include <filesystem>
 #include <string>
 #include <cctype>
 #include <unordered_map>
@@ -82,6 +83,29 @@ namespace UrlLib
         static void ToLower(std::string& s)
         {
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
+        }
+
+
+        std::wstring ResolveSymlink(const std::wstring& path)
+        {
+            //if (m_symlinkResolutionType == UrlSymlinkResolutionType::DoNotResolveSymlinks)
+            //{
+            //    return path;
+            //}
+
+            std::wstring resolvedPath{path};
+
+            while (std::filesystem::is_symlink(resolvedPath))
+            {
+                resolvedPath = std::filesystem::read_symlink(resolvedPath);
+
+                //if (m_symlinkResolutionType != UrlSymlinkResolutionType::ResolveSymlinkRecursively)
+                //{
+                //    break;
+                //}
+            }
+
+            return std::move(resolvedPath);
         }
 
         arcana::cancellation_source m_cancellationSource{};

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -79,7 +79,7 @@ namespace UrlLib
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
             return s;
         }
-        
+
         static void ToLower(std::string& s)
         {
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
@@ -97,7 +97,7 @@ namespace UrlLib
 
             while (std::filesystem::is_symlink(resolvedPath))
             {
-                resolvedPath = std::filesystem::read_symlink(resolvedPath);
+                resolvedPath = std::filesystem::read_symlink(resolvedPath).wstring();
 
                 //if (m_symlinkResolutionType != UrlSymlinkResolutionType::ResolveSymlinkRecursively)
                 //{

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -85,29 +85,6 @@ namespace UrlLib
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
         }
 
-
-        std::wstring ResolveSymlink(const std::wstring& path)
-        {
-            //if (m_symlinkResolutionType == UrlSymlinkResolutionType::DoNotResolveSymlinks)
-            //{
-            //    return path;
-            //}
-
-            std::wstring resolvedPath{path};
-
-            while (std::filesystem::is_symlink(resolvedPath))
-            {
-                resolvedPath = std::filesystem::read_symlink(resolvedPath).wstring();
-
-                //if (m_symlinkResolutionType != UrlSymlinkResolutionType::ResolveSymlinkRecursively)
-                //{
-                //    break;
-                //}
-            }
-
-            return std::move(resolvedPath);
-        }
-
         arcana::cancellation_source m_cancellationSource{};
         UrlResponseType m_responseType{UrlResponseType::String};
         UrlMethod m_method{UrlMethod::Get};

--- a/Source/UrlRequest_Windows.cpp
+++ b/Source/UrlRequest_Windows.cpp
@@ -58,7 +58,7 @@ namespace UrlLib
                 resolvedPath = std::filesystem::read_symlink(resolvedPath).wstring();
             }
 
-            std::replace(resolvedPath.begin(), resolvedPath.end(), '/', '\\');
+            std::replace(resolvedPath.begin(), resolvedPath.end(), L'/', L'\\');
 
             return std::move(resolvedPath);
         }
@@ -82,7 +82,7 @@ namespace UrlLib
                     auto path = GetLocalPath(m_uri);
                     if (m_uri.SchemeName() == L"app")
                     {
-                        path = std::wstring(GetInstalledLocation()) + L"\\" + path;
+                        path = std::wstring(GetInstalledLocation()) + L'\\' + path;
                     }
 
                     path = ResolveSymlink(path);
@@ -115,7 +115,7 @@ namespace UrlLib
 
                     m_requestHeaders.clear();
 
-                    // check the method 
+                    // check the method
                     if (m_method == UrlMethod::Post)
                     {
                         // if post, set the content type

--- a/Source/UrlRequest_Windows.cpp
+++ b/Source/UrlRequest_Windows.cpp
@@ -48,6 +48,20 @@ namespace UrlLib
             std::replace(path.begin(), path.end(), '/', '\\');
             return std::move(path);
         }
+
+        std::wstring ResolveSymlink(const std::wstring& path)
+        {
+            std::wstring resolvedPath{path};
+
+            while (std::filesystem::is_symlink(resolvedPath))
+            {
+                resolvedPath = std::filesystem::read_symlink(resolvedPath).wstring();
+            }
+
+            std::replace(resolvedPath.begin(), resolvedPath.end(), '/', '\\');
+
+            return std::move(resolvedPath);
+        }
     }
 
     class UrlRequest::Impl : public ImplBase
@@ -72,7 +86,6 @@ namespace UrlLib
                     }
 
                     path = ResolveSymlink(path);
-                    std::replace(path.begin(), path.end(), '/', '\\');
 
                     return arcana::create_task<std::exception_ptr>(Storage::StorageFile::GetFileFromPathAsync(path))
                         .then(arcana::inline_scheduler, m_cancellationSource, [this](Storage::StorageFile file) {


### PR DESCRIPTION
On macOS and Linux, app:/// and file:/// URLs that point to symlinks automatically resolve to the target file, but not on Windows.

This change resolves symlinks programmatically on Windows so the behavior is consistent across all platforms.

Unit tests are in the JsRuntimeHost repo in PR https://github.com/BabylonJS/JsRuntimeHost/pull/49.