### PR TITLE
Fire onClose after onError on all WebSocket error paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_Declare(arcana.cpp
     GIT_TAG        7c6be8aaa29effbc8ee1a2217388fb6e399150d2)
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
-    GIT_TAG        2d5af72259cc73e5f249d3c99bee2010be9cb042)
+    GIT_TAG        2e85a8d43b89246c460112c9e5546ad54b6e87b4)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
     GIT_TAG dc750e7f69dad76779419df6442f834c57a30a1f)

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -49,6 +49,7 @@
         {
             NSString *errorMessage = [error localizedDescription];
             errorCallback(errorMessage);
+            [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
         }
     }];
 }
@@ -61,6 +62,7 @@
         {
             NSString *errorMessage = [error localizedDescription];
             errorCallback(errorMessage);
+            [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
         }
         else if (message.type == NSURLSessionWebSocketMessageTypeString)
         {
@@ -83,6 +85,7 @@
     {
         NSString *errorMessage = [error localizedDescription];
         errorCallback(errorMessage);
+        [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
     }
 }
 
@@ -99,6 +102,10 @@
 
 - (void)invalidateAndCancelWithCloseCode:(int)code reason:(NSString *) reason
 {
+    if (!session)
+    {
+        return;
+    }
     webSocketTask = nil;
     [session invalidateAndCancel];
     session = nil;

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -47,9 +47,7 @@
     {
         if (error) 
         {
-            NSString *errorMessage = [error localizedDescription];
-            errorCallback(errorMessage);
-            [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
+            [self invalidateAndCancelWithCloseCode:1006 reason:[error localizedDescription]];
         }
     }];
 }
@@ -60,9 +58,7 @@
     {
         if (error) 
         {
-            NSString *errorMessage = [error localizedDescription];
-            errorCallback(errorMessage);
-            [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
+            [self invalidateAndCancelWithCloseCode:1006 reason:[error localizedDescription]];
             return;
         }
         else if (message.type == NSURLSessionWebSocketMessageTypeString)
@@ -84,23 +80,17 @@
 {
     if (error && session)
     {
-        NSString *errorMessage = [error localizedDescription];
-        errorCallback(errorMessage);
-        [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
+        [self invalidateAndCancelWithCloseCode:1006 reason:[error localizedDescription]];
     }
 }
 
 - (void)URLSession:(NSURLSession *)session webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask didCloseWithCloseCode:(NSInteger)code reason:(NSData *)reason  API_AVAILABLE(ios(13.0))
 {
     NSString *reasonStr = [[NSString alloc] initWithData:reason encoding:NSUTF8StringEncoding];
-    if (code != 1000)
-    {
-        errorCallback(reasonStr);
-    }
-
     [self invalidateAndCancelWithCloseCode:(int)code reason:reasonStr];
 }
 
+// Close-once helper. Fires onError for abnormal codes, then onClose exactly once.
 - (void)invalidateAndCancelWithCloseCode:(int)code reason:(NSString *) reason
 {
     if (!session)
@@ -110,6 +100,10 @@
     webSocketTask = nil;
     [session invalidateAndCancel];
     session = nil;
+    if (code != 1000)
+    {
+        errorCallback(reason);
+    }
     closeCallback(code, reason);
 }
 

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -63,6 +63,7 @@
             NSString *errorMessage = [error localizedDescription];
             errorCallback(errorMessage);
             [self invalidateAndCancelWithCloseCode:1006 reason:errorMessage];
+            return;
         }
         else if (message.type == NSURLSessionWebSocketMessageTypeString)
         {
@@ -79,9 +80,9 @@
     [self receiveMessage];
 }
 
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error 
+- (void)URLSession:(NSURLSession *)theSession task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error 
 {
-    if (error)
+    if (error && session)
     {
         NSString *errorMessage = [error localizedDescription];
         errorCallback(errorMessage);

--- a/Source/WebSocket_Windows.cpp
+++ b/Source/WebSocket_Windows.cpp
@@ -51,17 +51,14 @@ namespace UrlLib
                             }
                             catch (const std::exception& ex)
                             {
-                                m_onError(ex.what());
-                                m_onClose(1006, ex.what());
+                                CloseWithError(1006, ex.what());
                             }
                         }
                     });
             }
             catch (winrt::hresult_error const& ex)
             {
-                std::string errorMessage = winrt::to_string(ex.message());
-                m_onError(errorMessage);
-                m_onClose(1006, errorMessage);
+                CloseWithError(1006, winrt::to_string(ex.message()));
             }
         }
 
@@ -94,17 +91,14 @@ namespace UrlLib
                             }
                             catch (const std::exception& ex)
                             {
-                                m_onError(ex.what());
-                                m_onClose(1006, ex.what());
+                                CloseWithError(1006, ex.what());
                             }
                         }
                     });
             }
             catch (hresult_error const& ex)
             {
-                std::string errorMessage = winrt::to_string(ex.message());
-                m_onError(errorMessage);
-                m_onClose(1006, errorMessage);
+                CloseWithError(1006, winrt::to_string(ex.message()));
             }
         }
 
@@ -116,16 +110,14 @@ namespace UrlLib
     private:
         void OnWebSocketClosed(Windows::Networking::Sockets::IWebSocket const& /* sender */, Windows::Networking::Sockets::WebSocketClosedEventArgs const& args)
         {
-            if (m_closed)
-            {
-                return;
-            }
-            m_closed = true;
             if (args.Code() != 1000)
             {
-                m_onError(winrt::to_string(args.Reason()));
+                CloseWithError(args.Code(), winrt::to_string(args.Reason()));
             }
-            m_onClose(args.Code(), winrt::to_string(args.Reason()));
+            else
+            {
+                CloseNormally(args.Code(), winrt::to_string(args.Reason()));
+            }
         }
 
         void OnMessageReceived(Windows::Networking::Sockets::MessageWebSocket const& /* sender */, Windows::Networking::Sockets::MessageWebSocketMessageReceivedEventArgs const& args)
@@ -140,15 +132,34 @@ namespace UrlLib
             }
             catch (winrt::hresult_error const& ex)
             {
-                std::string errorMessage = winrt::to_string(ex.message());
-                m_onError(errorMessage);
-                m_onClose(1006, errorMessage);
+                CloseWithError(1006, winrt::to_string(ex.message()));
             }
         }
        
+        // Centralized close-once helpers. Thread-safe via atomic flag.
+        // Per the WebSocket spec, onError fires first, then onClose exactly once.
+        void CloseWithError(int code, const std::string& reason)
+        {
+            if (m_closed.exchange(true))
+            {
+                return;
+            }
+            m_onError(reason);
+            m_onClose(code, reason);
+        }
+
+        void CloseNormally(int code, const std::string& reason)
+        {
+            if (m_closed.exchange(true))
+            {
+                return;
+            }
+            m_onClose(code, reason);
+        }
+
         Windows::Networking::Sockets::MessageWebSocket m_webSocket;
         std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
-        bool m_closed{false};
+        std::atomic<bool> m_closed{false};
 
         event_token m_messageReceivedEventToken;
         event_token m_closedEventToken;

--- a/Source/WebSocket_Windows.cpp
+++ b/Source/WebSocket_Windows.cpp
@@ -51,14 +51,14 @@ namespace UrlLib
                             }
                             catch (const std::exception& ex)
                             {
-                                CloseWithError(1006, ex.what());
+                                CloseOnce(1006, ex.what());
                             }
                         }
                     });
             }
             catch (winrt::hresult_error const& ex)
             {
-                CloseWithError(1006, winrt::to_string(ex.message()));
+                CloseOnce(1006, winrt::to_string(ex.message()));
             }
         }
 
@@ -91,14 +91,14 @@ namespace UrlLib
                             }
                             catch (const std::exception& ex)
                             {
-                                CloseWithError(1006, ex.what());
+                                CloseOnce(1006, ex.what());
                             }
                         }
                     });
             }
             catch (hresult_error const& ex)
             {
-                CloseWithError(1006, winrt::to_string(ex.message()));
+                CloseOnce(1006, winrt::to_string(ex.message()));
             }
         }
 
@@ -110,14 +110,7 @@ namespace UrlLib
     private:
         void OnWebSocketClosed(Windows::Networking::Sockets::IWebSocket const& /* sender */, Windows::Networking::Sockets::WebSocketClosedEventArgs const& args)
         {
-            if (args.Code() != 1000)
-            {
-                CloseWithError(args.Code(), winrt::to_string(args.Reason()));
-            }
-            else
-            {
-                CloseNormally(args.Code(), winrt::to_string(args.Reason()));
-            }
+            CloseOnce(args.Code(), winrt::to_string(args.Reason()));
         }
 
         void OnMessageReceived(Windows::Networking::Sockets::MessageWebSocket const& /* sender */, Windows::Networking::Sockets::MessageWebSocketMessageReceivedEventArgs const& args)
@@ -132,27 +125,21 @@ namespace UrlLib
             }
             catch (winrt::hresult_error const& ex)
             {
-                CloseWithError(1006, winrt::to_string(ex.message()));
+                CloseOnce(1006, winrt::to_string(ex.message()));
             }
         }
        
-        // Centralized close-once helpers. Thread-safe via atomic flag.
-        // Per the WebSocket spec, onError fires first, then onClose exactly once.
-        void CloseWithError(int code, const std::string& reason)
+        // Close-once helper. Thread-safe via atomic flag.
+        // Fires onError for abnormal codes, then onClose exactly once.
+        void CloseOnce(int code, const std::string& reason)
         {
             if (m_closed.exchange(true))
             {
                 return;
             }
-            m_onError(reason);
-            m_onClose(code, reason);
-        }
-
-        void CloseNormally(int code, const std::string& reason)
-        {
-            if (m_closed.exchange(true))
+            if (code != 1000)
             {
-                return;
+                m_onError(reason);
             }
             m_onClose(code, reason);
         }

--- a/Source/WebSocket_Windows.cpp
+++ b/Source/WebSocket_Windows.cpp
@@ -52,6 +52,7 @@ namespace UrlLib
                             catch (const std::exception& ex)
                             {
                                 m_onError(ex.what());
+                                m_onClose(1006, ex.what());
                             }
                         }
                     });
@@ -60,6 +61,7 @@ namespace UrlLib
             {
                 std::string errorMessage = winrt::to_string(ex.message());
                 m_onError(errorMessage);
+                m_onClose(1006, errorMessage);
             }
         }
 
@@ -93,6 +95,7 @@ namespace UrlLib
                             catch (const std::exception& ex)
                             {
                                 m_onError(ex.what());
+                                m_onClose(1006, ex.what());
                             }
                         }
                     });
@@ -101,6 +104,7 @@ namespace UrlLib
             {
                 std::string errorMessage = winrt::to_string(ex.message());
                 m_onError(errorMessage);
+                m_onClose(1006, errorMessage);
             }
         }
 
@@ -112,6 +116,11 @@ namespace UrlLib
     private:
         void OnWebSocketClosed(Windows::Networking::Sockets::IWebSocket const& /* sender */, Windows::Networking::Sockets::WebSocketClosedEventArgs const& args)
         {
+            if (m_closed)
+            {
+                return;
+            }
+            m_closed = true;
             if (args.Code() != 1000)
             {
                 m_onError(winrt::to_string(args.Reason()));
@@ -133,11 +142,13 @@ namespace UrlLib
             {
                 std::string errorMessage = winrt::to_string(ex.message());
                 m_onError(errorMessage);
+                m_onClose(1006, errorMessage);
             }
         }
        
         Windows::Networking::Sockets::MessageWebSocket m_webSocket;
         std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
+        bool m_closed{false};
 
         event_token m_messageReceivedEventToken;
         event_token m_closedEventToken;


### PR DESCRIPTION
Fire onClose after onError on all WebSocket error paths per the spec.

## The Bug

Per the [WebSocket spec](https://html.spec.whatwg.org/multipage/web-sockets.html#feedback-from-the-protocol), `onclose` must always fire after `onerror`. The Windows and Apple implementations only fired `onError` on connection, send, and receive errors without a corresponding `onClose`, leaving consumers waiting for a close event that never came.

## Changes

**Windows (`WebSocket_Windows.cpp`):**
- Added `m_onClose(1006, ...)` after `m_onError` on all 5 error paths (connect async/sync, send async/sync, message receive)
- Made `OnWebSocketClosed` idempotent with `m_closed` flag to prevent double-close if the native layer also fires close

**Apple (`WebSocket_Apple_ObjC.m`):**
- Call `invalidateAndCancelWithCloseCode:1006` after `errorCallback` on all 3 error paths (send, receive, `didCompleteWithError`)
- Made `invalidateAndCancelWithCloseCode` idempotent (check `session != nil`) to prevent double-close

Code 1006 is used per the spec for abnormal closure (no close frame received).