### PR TITLE
Fix data races in Apple WebSocket for TSan safety

### DIFF
--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -29,12 +29,14 @@
 
 -(void) open
 {
+    NSURLSessionWebSocketTask* task;
     @synchronized(self)
     {
         session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:[[NSOperationQueue alloc] init]];
         webSocketTask = [session webSocketTaskWithURL:[NSURL URLWithString:websocketUrl]];
+        task = webSocketTask;
     }
-    [webSocketTask resume];
+    [task resume];
 }
 
 - (void) close 
@@ -151,7 +153,10 @@
     {
         errorCb(reason);
     }
-    closeCb(code, reason);
+    if (closeCb)
+    {
+        closeCb(code, reason);
+    }
 }
 
 @end

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -2,20 +2,20 @@
 
 @interface WebSocket_ObjC() <NSURLSessionWebSocketDelegate>
 {
-    NSURLSessionWebSocketTask *webSocketTask API_AVAILABLE(ios(13.0));
-    NSURLSession *session;
-    NSString *websocketUrl;
+    NSURLSessionWebSocketTask* webSocketTask API_AVAILABLE(ios(13.0));
+    NSURLSession* session;
+    NSString* websocketUrl;
     // store callbacks here
     void (^openCallback)();
-    void (^closeCallback)(int, NSString *);
-    void (^messageCallback)(NSString *);
-    void (^errorCallback)(NSString *);
+    void (^closeCallback)(int, NSString*);
+    void (^messageCallback)(NSString*);
+    void (^errorCallback)(NSString*);
 }
 @end
 
 @implementation WebSocket_ObjC
 
-- (instancetype)initWithCallbacks:(NSString *)url onOpen:(void (^)(void))onOpen onClose:(void (^)(int, NSString *))onClose onMessage:(void (^)(NSString *))onMessage onError:(void (^)(NSString *))onError
+- (instancetype)initWithCallbacks:(NSString*)url onOpen:(void (^)(void))onOpen onClose:(void (^)(int, NSString*))onClose onMessage:(void (^)(NSString*))onMessage onError:(void (^)(NSString*))onError
 {
     self = [super init];
     websocketUrl = url;
@@ -36,8 +36,8 @@
 
 - (void) close 
 {
-    NSURLSessionWebSocketTask *taskToCancel;
-    NSURLSession *sessionToInvalidate;
+    NSURLSessionWebSocketTask* taskToCancel;
+    NSURLSession* sessionToInvalidate;
 
     @synchronized(self)
     {
@@ -56,9 +56,9 @@
     closeCallback(1000, [NSString stringWithUTF8String:"Normal close."]);
 }
 
-- (void) sendMessage:(NSString *)message
+- (void) sendMessage:(NSString*)message
 {
-    NSURLSessionWebSocketTask *task;
+    NSURLSessionWebSocketTask* task;
     @synchronized(self)
     {
         task = webSocketTask;
@@ -67,7 +67,7 @@
     {
         return;
     }
-    [task sendMessage: [[NSURLSessionWebSocketMessage alloc] initWithString:message] completionHandler:^(NSError * _Nullable error)
+    [task sendMessage: [[NSURLSessionWebSocketMessage alloc] initWithString:message] completionHandler:^(NSError* _Nullable error)
     {
         if (error) 
         {
@@ -78,7 +78,7 @@
 
 - (void)receiveMessage
 {
-    NSURLSessionWebSocketTask *task;
+    NSURLSessionWebSocketTask* task;
     @synchronized(self)
     {
         task = webSocketTask;
@@ -87,7 +87,7 @@
     {
         return;
     }
-    [task receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage * _Nullable message, NSError * _Nullable error)
+    [task receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage* _Nullable message, NSError* _Nullable error)
     {
         if (error) 
         {
@@ -96,7 +96,7 @@
         }
         else if (message.type == NSURLSessionWebSocketMessageTypeString)
         {
-            void (^callback)(NSString *);
+            void (^callback)(NSString*);
             @synchronized(self)
             {
                 callback = messageCallback;
@@ -110,14 +110,14 @@
     }];
 }
 
-- (void)URLSession:(NSURLSession *)session webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask didOpenWithProtocol:(NSString *)protocol  API_AVAILABLE(ios(13.0))
+- (void)URLSession:(NSURLSession*)session webSocketTask:(NSURLSessionWebSocketTask*)webSocketTask didOpenWithProtocol:(NSString*)protocol  API_AVAILABLE(ios(13.0))
 {
     openCallback();
     // run the loop to receive messages
     [self receiveMessage];
 }
 
-- (void)URLSession:(NSURLSession *)theSession task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error 
+- (void)URLSession:(NSURLSession*)theSession task:(NSURLSessionTask*)task didCompleteWithError:(NSError*)error 
 {
     if (error)
     {
@@ -125,19 +125,19 @@
     }
 }
 
-- (void)URLSession:(NSURLSession *)session webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask didCloseWithCloseCode:(NSInteger)code reason:(NSData *)reason  API_AVAILABLE(ios(13.0))
+- (void)URLSession:(NSURLSession*)session webSocketTask:(NSURLSessionWebSocketTask*)webSocketTask didCloseWithCloseCode:(NSInteger)code reason:(NSData*)reason  API_AVAILABLE(ios(13.0))
 {
-    NSString *reasonStr = [[NSString alloc] initWithData:reason encoding:NSUTF8StringEncoding];
+    NSString* reasonStr = [[NSString alloc] initWithData:reason encoding:NSUTF8StringEncoding];
     [self invalidateAndCancelWithCloseCode:(int)code reason:reasonStr];
 }
 
 // Close-once helper. Fires onError for abnormal codes, then onClose exactly once.
 // Callbacks are invoked outside the lock to avoid reentrancy issues.
-- (void)invalidateAndCancelWithCloseCode:(int)code reason:(NSString *) reason
+- (void)invalidateAndCancelWithCloseCode:(int)code reason:(NSString*) reason
 {
-    NSURLSession *sessionToInvalidate;
-    void (^errorCb)(NSString *);
-    void (^closeCb)(int, NSString *);
+    NSURLSession* sessionToInvalidate;
+    void (^errorCb)(NSString*);
+    void (^closeCb)(int, NSString*);
 
     @synchronized(self)
     {

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -36,14 +36,38 @@
 
 - (void) close 
 {
-    [webSocketTask cancel];
-    NSString *closeStr = [NSString stringWithUTF8String:"Normal close."];
-    [self invalidateAndCancelWithCloseCode:1000 reason:closeStr];
+    NSURLSessionWebSocketTask *taskToCancel;
+    NSURLSession *sessionToInvalidate;
+
+    @synchronized(self)
+    {
+        if (!session)
+        {
+            return;
+        }
+        taskToCancel = webSocketTask;
+        webSocketTask = nil;
+        sessionToInvalidate = session;
+        session = nil;
+    }
+
+    [taskToCancel cancel];
+    [sessionToInvalidate invalidateAndCancel];
+    closeCallback(1000, [NSString stringWithUTF8String:"Normal close."]);
 }
 
 - (void) sendMessage:(NSString *)message
 {
-    [webSocketTask sendMessage: [[NSURLSessionWebSocketMessage alloc] initWithString:message] completionHandler:^(NSError * _Nullable error)
+    NSURLSessionWebSocketTask *task;
+    @synchronized(self)
+    {
+        task = webSocketTask;
+    }
+    if (!task)
+    {
+        return;
+    }
+    [task sendMessage: [[NSURLSessionWebSocketMessage alloc] initWithString:message] completionHandler:^(NSError * _Nullable error)
     {
         if (error) 
         {
@@ -54,7 +78,16 @@
 
 - (void)receiveMessage
 {
-    [webSocketTask receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage * _Nullable message, NSError * _Nullable error)
+    NSURLSessionWebSocketTask *task;
+    @synchronized(self)
+    {
+        task = webSocketTask;
+    }
+    if (!task)
+    {
+        return;
+    }
+    [task receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage * _Nullable message, NSError * _Nullable error)
     {
         if (error) 
         {
@@ -63,7 +96,15 @@
         }
         else if (message.type == NSURLSessionWebSocketMessageTypeString)
         {
-            messageCallback(message.string);
+            void (^callback)(NSString *);
+            @synchronized(self)
+            {
+                callback = messageCallback;
+            }
+            if (callback)
+            {
+                callback(message.string);
+            }
         }
         [self receiveMessage];
     }];
@@ -78,7 +119,7 @@
 
 - (void)URLSession:(NSURLSession *)theSession task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error 
 {
-    if (error && session)
+    if (error)
     {
         [self invalidateAndCancelWithCloseCode:1006 reason:[error localizedDescription]];
     }
@@ -91,20 +132,32 @@
 }
 
 // Close-once helper. Fires onError for abnormal codes, then onClose exactly once.
+// Callbacks are invoked outside the lock to avoid reentrancy issues.
 - (void)invalidateAndCancelWithCloseCode:(int)code reason:(NSString *) reason
 {
-    if (!session)
+    NSURLSession *sessionToInvalidate;
+    void (^errorCb)(NSString *);
+    void (^closeCb)(int, NSString *);
+
+    @synchronized(self)
     {
-        return;
+        if (!session)
+        {
+            return;
+        }
+        webSocketTask = nil;
+        sessionToInvalidate = session;
+        session = nil;
+        errorCb = (code != 1000) ? errorCallback : nil;
+        closeCb = closeCallback;
     }
-    webSocketTask = nil;
-    [session invalidateAndCancel];
-    session = nil;
-    if (code != 1000)
+
+    [sessionToInvalidate invalidateAndCancel];
+    if (errorCb)
     {
-        errorCallback(reason);
+        errorCb(reason);
     }
-    closeCallback(code, reason);
+    closeCb(code, reason);
 }
 
 @end

--- a/Source/WebSocket_Apple_ObjC.m
+++ b/Source/WebSocket_Apple_ObjC.m
@@ -29,31 +29,17 @@
 
 -(void) open
 {
-    session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:[[NSOperationQueue alloc] init]];
-    webSocketTask = [session webSocketTaskWithURL:[NSURL URLWithString:websocketUrl]];
+    @synchronized(self)
+    {
+        session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:[[NSOperationQueue alloc] init]];
+        webSocketTask = [session webSocketTaskWithURL:[NSURL URLWithString:websocketUrl]];
+    }
     [webSocketTask resume];
 }
 
 - (void) close 
 {
-    NSURLSessionWebSocketTask* taskToCancel;
-    NSURLSession* sessionToInvalidate;
-
-    @synchronized(self)
-    {
-        if (!session)
-        {
-            return;
-        }
-        taskToCancel = webSocketTask;
-        webSocketTask = nil;
-        sessionToInvalidate = session;
-        session = nil;
-    }
-
-    [taskToCancel cancel];
-    [sessionToInvalidate invalidateAndCancel];
-    closeCallback(1000, [NSString stringWithUTF8String:"Normal close."]);
+    [self invalidateAndCancelWithCloseCode:1000 reason:[NSString stringWithUTF8String:"Normal close."]];
 }
 
 - (void) sendMessage:(NSString*)message
@@ -112,7 +98,15 @@
 
 - (void)URLSession:(NSURLSession*)session webSocketTask:(NSURLSessionWebSocketTask*)webSocketTask didOpenWithProtocol:(NSString*)protocol  API_AVAILABLE(ios(13.0))
 {
-    openCallback();
+    void (^callback)();
+    @synchronized(self)
+    {
+        callback = openCallback;
+    }
+    if (callback)
+    {
+        callback();
+    }
     // run the loop to receive messages
     [self receiveMessage];
 }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Fix data races in Apple WebSocket detected by ThreadSanitizer.

## Problem

TSan detected races in `WebSocket_Apple_ObjC.m`: the JS thread calling `close()` writes to `webSocketTask`/`session` while GCD delegate threads read them concurrently in `didCompleteWithError`, `receiveMessage`, etc. No synchronization existed.

## Fix

- Add `@synchronized(self)` to all methods accessing `webSocketTask`, `session`, and callbacks
- Copy ivars to locals under the lock, operate on locals outside the lock
- `open`: wraps `session`/`webSocketTask` assignment in `@synchronized`, copies task to local before `resume`
- `close`: routes through `invalidateAndCancelWithCloseCode` instead of duplicating teardown logic
- `didOpenWithProtocol`: copies `openCallback` under `@synchronized` before invoking
- `invalidateAndCancelWithCloseCode`: nil-guards `closeCb` invocation for safety
- Preserves close-once semantics from #26 while making them thread-safe

## Style

- Standardize pointer style to `Type*` (C++ convention) throughout the file, matching the majority of `.mm` files in the BabylonNative ecosystem
