### PR TITLE
Don't crash on missing local files on Unix and Apple

### DIFF
--- a/Source/UrlRequest_Android.cpp
+++ b/Source/UrlRequest_Android.cpp
@@ -34,6 +34,9 @@ namespace UrlLib
     public:
         void Open(UrlMethod method, const std::string& url)
         {
+            ResetForOpen();
+            m_responseBuffer.clear();
+
             m_method = method;
             Uri uri{Uri::Parse(url.data())};
             // If the URL string doesn't contain a scheme, the URI object's scheme will be null. We throw in this case

--- a/Source/UrlRequest_Apple.mm
+++ b/Source/UrlRequest_Apple.mm
@@ -24,6 +24,7 @@ namespace UrlLib
     public:
         void Open(UrlMethod method, const std::string& url)
         {
+            m_statusCode = UrlStatusCode::None;
             m_method = method;
             m_url = [NSURL URLWithString:[[NSString stringWithUTF8String:url.data()] stringByAddingPercentEncodingWithAllowedCharacters:URLAllowedCharacterSet]];
             if (!m_url || !m_url.scheme)

--- a/Source/UrlRequest_Apple.mm
+++ b/Source/UrlRequest_Apple.mm
@@ -24,7 +24,9 @@ namespace UrlLib
     public:
         void Open(UrlMethod method, const std::string& url)
         {
-            m_statusCode = UrlStatusCode::None;
+            ResetForOpen();
+            m_responseBuffer = nil;
+
             m_method = method;
             m_url = [NSURL URLWithString:[[NSString stringWithUTF8String:url.data()] stringByAddingPercentEncodingWithAllowedCharacters:URLAllowedCharacterSet]];
             if (!m_url || !m_url.scheme)

--- a/Source/UrlRequest_Apple.mm
+++ b/Source/UrlRequest_Apple.mm
@@ -36,7 +36,12 @@ namespace UrlLib
                 NSString* path = [[NSBundle mainBundle] pathForResource:[m_url.path substringFromIndex:1] ofType:nil];
                 if (path == nil)
                 {
-                    throw std::runtime_error{"No file exists at local path"};
+                    // No bundled resource at this path. Don't throw -- let SendAsync's existing
+                    // `if (m_url == nil)` branch complete the task and retain the default status
+                    // code of 0 to indicate a client side error. This matches Win32 / UWP / Unix
+                    // semantics for missing local files.
+                    m_url = nil;
+                    return;
                 }
                 m_url = [NSURL fileURLWithPath:path];
             }

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -84,6 +84,19 @@ namespace UrlLib
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
         }
 
+        // Reset the per-request response state that lives in ImplBase. Each platform's `Open()`
+        // calls this at the start so a single `UrlRequest` can be reused across requests without
+        // leaking prior status / URL / body / headers. Platform-specific response buffers live in
+        // each `Impl` (different types per backend) and must be reset by the platform's `Open()`
+        // alongside this call.
+        void ResetForOpen()
+        {
+            m_statusCode = UrlStatusCode::None;
+            m_responseUrl.clear();
+            m_responseString.clear();
+            m_headers.clear();
+        }
+
         arcana::cancellation_source m_cancellationSource{};
         UrlResponseType m_responseType{UrlResponseType::String};
         UrlMethod m_method{UrlMethod::Get};

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -178,18 +178,30 @@ namespace UrlLib
 
             m_thread.emplace([this, taskCompletionSource]() mutable
             {
-                curl_check(curl_easy_perform(m_curl));
+                try
+                {
+                    curl_check(curl_easy_perform(m_curl));
 
-                long codep{};
-                curl_check(curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &codep));
-                if (codep == 0 && m_file)
-                {
-                    // File scheme always returns 0
-                    m_statusCode = UrlStatusCode::Ok;
+                    long codep{};
+                    curl_check(curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &codep));
+                    if (codep == 0 && m_file)
+                    {
+                        // File scheme always returns 0
+                        m_statusCode = UrlStatusCode::Ok;
+                    }
+                    else
+                    {
+                        m_statusCode = static_cast<UrlStatusCode>(codep);
+                    }
                 }
-                else
+                catch (const std::exception&)
                 {
-                    m_statusCode = static_cast<UrlStatusCode>(codep);
+                    // Retain the default status code of 0 to indicate a client side error,
+                    // matching the convention of UrlRequest_UWP.cpp's catch(winrt::hresult_error)
+                    // and UrlRequest_Apple.mm's `m_url == nil` branch. Without this catch any
+                    // libcurl failure (e.g. CURLE_FILE_COULDNT_READ_FILE (37) for a missing local
+                    // `file://` or rewritten `app:///` target) would escape this std::thread and
+                    // call std::terminate.
                 }
 
                 taskCompletionSource.complete();

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -39,6 +39,7 @@ namespace UrlLib
         {
             Cleanup();
 
+            m_statusCode = UrlStatusCode::None;
             m_method = method;
 
             if (m_method == UrlMethod::Post)

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -39,7 +39,9 @@ namespace UrlLib
         {
             Cleanup();
 
-            m_statusCode = UrlStatusCode::None;
+            ResetForOpen();
+            m_responseBuffer.clear();
+
             m_method = method;
 
             if (m_method == UrlMethod::Post)

--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -46,6 +46,10 @@ namespace UrlLib
     public:
         void Open(UrlMethod method, const std::string& url)
         {
+            ResetForOpen();
+            m_responseBuffer = nullptr;
+            m_fileResponseBuffer.clear();
+
             m_method = method;
             m_uri = Foundation::Uri{winrt::to_hstring(url)};
         }


### PR DESCRIPTION
## Problem

Two pre-existing bugs caused a missing local `app:///` (or `file://`) URL request to crash the host process instead of producing a clean failure surfaceable to the consumer:

### Bug 1: Unix worker thread terminates on missing local file

`Source/UrlRequest_Unix.cpp` -- the worker `std::thread` in `PerformAsync` calls `curl_check(curl_easy_perform(m_curl))`. `curl_check` throws `std::runtime_error` on any non-OK libcurl code -- including `CURLE_FILE_COULDNT_READ_FILE` (37) for a missing local file. The uncaught exception in the `std::thread` callable calls `std::terminate`.

Reproduced by JsRuntimeHost CI: https://github.com/BabylonJS/JsRuntimeHost/actions/runs/25810440805
``
[log]     should have status=404 for a file that does not exist (204ms)
terminate called after throwing an instance of 'std::runtime_error'
  what():  CURL call failed with code (37)
./UnitTests: line 1:  3639 Aborted                 (core dumped)
``

### Bug 2: Apple `Open` throws synchronously on missing `app:///`

`Source/UrlRequest_Apple.mm:39` -- `Open` throws `std::runtime_error{"No file exists at local path"}` synchronously when `[NSBundle pathForResource:]` returns nil for an `app:///` URL. This propagates back to the JS caller through `xhr.open()` as a synchronous throw, breaking platform parity: every other platform defers the failure to the async `SendAsync` path with `status=0 + complete`.

## Fix

Make both platforms match the existing convention (already implemented by `UrlRequest_UWP.cpp` `catch (winrt::hresult_error)` and `UrlRequest_Win32.cpp` non-success branch): **retain the default status code of 0 on client-side failure, complete the task normally**.

- **Unix**: wrap the worker thread's libcurl calls in try/catch; on failure, retain status 0 and complete normally.
- **Apple**: in `Open`, instead of throwing when `pathForResource:` returns nil, set `m_url = nil` and let `SendAsync`'s existing `if (m_url == nil)` branch handle it.

After these fixes, JS-side observers (e.g. via JsRuntimeHost's XMLHttpRequest polyfill + https://github.com/BabylonJS/JsRuntimeHost/pull/165) will reliably receive an `error` event on missing local files across all platforms instead of seeing the host crash.

## Tests

UrlLib doesn't have its own test suite. End-to-end verification will land in BabylonJS/JsRuntimeHost once both PR #165 (XHR async-failure events) and this UrlLib fix merge -- at that point a regression test for the `app:///` missing-file case can be safely added to JsRuntimeHost's `tests.ts` ([see this comment](https://github.com/BabylonJS/JsRuntimeHost/pull/165#issuecomment-4443231845)). Locally testable today via the BabylonNative Playground (any test exercising a missing local script/asset on Linux or macOS).

cc @bghgary