### PR TITLE
Fix UWP build: guard m_fileResponseBuffer.clear() with WINAPI_PARTITION_DESKTOP

### DIFF
--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -48,7 +48,9 @@ namespace UrlLib
         {
             ResetForOpen();
             m_responseBuffer = nullptr;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
             m_fileResponseBuffer.clear();
+#endif
 
             m_method = method;
             m_uri = Foundation::Uri{winrt::to_hstring(url)};


### PR DESCRIPTION
Follow-up to #28: the unconditional `m_fileResponseBuffer.clear()` call added to `Open()` in `UrlRequest_Windows_Shared.h` references a member that only exists on Win32 desktop. UWP builds fail with:

```
UrlRequest_Windows_Shared.h(51,13): error C2065: 'm_fileResponseBuffer': undeclared identifier
  (compiling source file '../../_deps/urllib-src/Source/UrlRequest_UWP.cpp')
```

Spotted by [JsRuntimeHost #168](https://github.com/BabylonJS/JsRuntimeHost/pull/168) CI (4 UWP build jobs failing: `UWP_x64_Chakra`, `UWP_x64_JSI`, `UWP_x64_V8`, `UWP_arm64_JSI`).

The member declaration at line 150 of the same header is already gated by `#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)`. The fix is to apply the same guard around the `clear()` call so it only fires on desktop.

After this, `JsRuntimeHost #168` (UrlLib pin bump) goes green on UWP.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>