### PR TITLE
Expose HTTP status reason phrase (StatusText)

### DIFF
--- a/Include/UrlLib/UrlLib.h
+++ b/Include/UrlLib/UrlLib.h
@@ -61,6 +61,8 @@ namespace UrlLib
         
         UrlStatusCode StatusCode() const;
 
+        std::string_view StatusText() const;
+
         std::string_view ResponseUrl() const;
 
         std::string_view ResponseString() const;

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -61,6 +61,20 @@ namespace UrlLib
             return m_statusCode;
         }
 
+        // Returns the HTTP status reason phrase. Prefers the phrase carried on the wire
+        // (HTTP/1.x status line, captured by the platform backend into `m_statusText`).
+        // When the transport carries no reason phrase (HTTP/2+, or a backend that does not
+        // expose it), falls back to a canonical code->text table. Returns "" for unknown codes.
+        std::string_view StatusText() const
+        {
+            if (!m_statusText.empty())
+            {
+                return m_statusText;
+            }
+
+            return ReasonPhraseForStatusCode(static_cast<int>(m_statusCode));
+        }
+
         std::string_view ResponseUrl()
         {
             return m_responseUrl;
@@ -84,6 +98,63 @@ namespace UrlLib
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
         }
 
+        // Canonical HTTP reason phrases, used as a fallback when the transport does not carry
+        // a reason phrase on the wire (HTTP/2+ status lines omit it, and some platform HTTP
+        // stacks don't surface it). Returns "" for codes not in the table.
+        static std::string_view ReasonPhraseForStatusCode(int statusCode)
+        {
+            switch (statusCode)
+            {
+                case 100: return "Continue";
+                case 101: return "Switching Protocols";
+                case 200: return "OK";
+                case 201: return "Created";
+                case 202: return "Accepted";
+                case 203: return "Non-Authoritative Information";
+                case 204: return "No Content";
+                case 205: return "Reset Content";
+                case 206: return "Partial Content";
+                case 300: return "Multiple Choices";
+                case 301: return "Moved Permanently";
+                case 302: return "Found";
+                case 303: return "See Other";
+                case 304: return "Not Modified";
+                case 307: return "Temporary Redirect";
+                case 308: return "Permanent Redirect";
+                case 400: return "Bad Request";
+                case 401: return "Unauthorized";
+                case 402: return "Payment Required";
+                case 403: return "Forbidden";
+                case 404: return "Not Found";
+                case 405: return "Method Not Allowed";
+                case 406: return "Not Acceptable";
+                case 407: return "Proxy Authentication Required";
+                case 408: return "Request Timeout";
+                case 409: return "Conflict";
+                case 410: return "Gone";
+                case 411: return "Length Required";
+                case 412: return "Precondition Failed";
+                case 413: return "Payload Too Large";
+                case 414: return "URI Too Long";
+                case 415: return "Unsupported Media Type";
+                case 416: return "Range Not Satisfiable";
+                case 417: return "Expectation Failed";
+                case 426: return "Upgrade Required";
+                case 428: return "Precondition Required";
+                case 429: return "Too Many Requests";
+                case 431: return "Request Header Fields Too Large";
+                case 451: return "Unavailable For Legal Reasons";
+                case 500: return "Internal Server Error";
+                case 501: return "Not Implemented";
+                case 502: return "Bad Gateway";
+                case 503: return "Service Unavailable";
+                case 504: return "Gateway Timeout";
+                case 505: return "HTTP Version Not Supported";
+                case 511: return "Network Authentication Required";
+                default: return "";
+            }
+        }
+
         // Reset the per-request response state that lives in ImplBase. Each platform's `Open()`
         // calls this at the start so a single `UrlRequest` can be reused across requests without
         // leaking prior status / URL / body / headers. Platform-specific response buffers live in
@@ -92,6 +163,7 @@ namespace UrlLib
         void ResetForOpen()
         {
             m_statusCode = UrlStatusCode::None;
+            m_statusText.clear();
             m_responseUrl.clear();
             m_responseString.clear();
             m_headers.clear();
@@ -101,6 +173,7 @@ namespace UrlLib
         UrlResponseType m_responseType{UrlResponseType::String};
         UrlMethod m_method{UrlMethod::Get};
         UrlStatusCode m_statusCode{UrlStatusCode::None};
+        std::string m_statusText{};
         std::string m_responseUrl{};
         std::string m_responseString{};
         std::unordered_map<std::string, std::string> m_headers;

--- a/Source/UrlRequest_Shared.h
+++ b/Source/UrlRequest_Shared.h
@@ -67,6 +67,11 @@ namespace UrlLib
         return m_impl->StatusCode();
     }
 
+    std::string_view UrlRequest::StatusText() const
+    {
+        return m_impl->StatusText();
+    }
+
     std::string_view UrlRequest::ResponseUrl() const
     {
         return m_impl->ResponseUrl();

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -2,6 +2,7 @@
 
 #include <curl/curl.h>
 #include <unistd.h>
+#include <cstring>
 #include <filesystem>
 #include <cassert>
 #include <sstream>
@@ -218,6 +219,39 @@ namespace UrlLib
             if (nitems > 0)
             {
                 char* bufferEnd = buffer + nitems;
+
+                // Status line: "HTTP/<version> <code>[ <reason>]\r\n". HTTP/1.x carries a reason
+                // phrase; HTTP/2+ omits it. curl delivers a fresh status line for every response
+                // in the chain (e.g. each redirect hop), so reset and let the final one win.
+                if (nitems >= 5 && std::strncmp(buffer, "HTTP/", 5) == 0)
+                {
+                    auto& impl = *static_cast<Impl*>(userdata);
+                    impl.m_statusText.clear();
+
+                    // Skip "HTTP/<version>" then the spaces and the numeric status code.
+                    char* cursor = buffer;
+                    for (; cursor < bufferEnd && *cursor != ' '; ++cursor) {}      // end of version token
+                    for (; cursor < bufferEnd && *cursor == ' '; ++cursor) {}      // spaces before code
+                    for (; cursor < bufferEnd && *cursor != ' '; ++cursor) {}      // status code digits
+                    for (; cursor < bufferEnd && *cursor == ' '; ++cursor) {}      // spaces before reason
+
+                    char* reasonEnd = bufferEnd;
+                    for (; reasonEnd - 1 >= cursor; --reasonEnd)
+                    {
+                        auto ch = *(reasonEnd - 1);
+                        if (ch != '\r' && ch != '\n' && ch != ' ')
+                        {
+                            break;
+                        }
+                    }
+
+                    if (cursor < reasonEnd)
+                    {
+                        impl.m_statusText.assign(cursor, reasonEnd);
+                    }
+
+                    return nitems * size;
+                }
 
                 char* keyStart = buffer;
                 char* keyEnd = keyStart;

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -216,14 +216,17 @@ namespace UrlLib
 
         static size_t HeaderCallback(char* buffer, size_t size, size_t nitems, void* userdata)
         {
-            if (nitems > 0)
+            // libcurl passes the header bytes as `size` chunks of `nitems`; the valid length is
+            // their product. (curl currently always uses size == 1 for headers, but don't rely on it.)
+            const size_t length = size * nitems;
+            if (length > 0)
             {
-                char* bufferEnd = buffer + nitems;
+                char* bufferEnd = buffer + length;
 
                 // Status line: "HTTP/<version> <code>[ <reason>]\r\n". HTTP/1.x carries a reason
                 // phrase; HTTP/2+ omits it. curl delivers a fresh status line for every response
                 // in the chain (e.g. each redirect hop), so reset and let the final one win.
-                if (nitems >= 5 && std::strncmp(buffer, "HTTP/", 5) == 0)
+                if (length >= 5 && std::strncmp(buffer, "HTTP/", 5) == 0)
                 {
                     auto& impl = *static_cast<Impl*>(userdata);
                     impl.m_statusText.clear();

--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -100,6 +100,7 @@ namespace UrlLib
                 .then(arcana::inline_scheduler, m_cancellationSource, [this](Web::Http::HttpResponseMessage responseMessage)
                 {
                     m_statusCode = static_cast<UrlStatusCode>(responseMessage.StatusCode());
+                    m_statusText = winrt::to_string(responseMessage.ReasonPhrase());
                     if (!responseMessage.IsSuccessStatusCode())
                     {
                         return arcana::task_from_result<std::exception_ptr>();

--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -125,7 +125,11 @@ namespace UrlLib
                                 .then(arcana::inline_scheduler, m_cancellationSource, [this](winrt::hstring string)
                                 {
                                     m_responseString = winrt::to_string(string);
+                                    // This backend normalizes any successful (2xx) response to Ok once the
+                                    // body has been read. Clear the wire phrase so StatusText() stays
+                                    // consistent with the normalized status code (falls back to "OK").
                                     m_statusCode = UrlStatusCode::Ok;
+                                    m_statusText.clear();
                                 });
                         }
                         case UrlResponseType::Buffer:
@@ -134,7 +138,10 @@ namespace UrlLib
                                 .then(arcana::inline_scheduler, m_cancellationSource, [this](Storage::Streams::IBuffer buffer)
                                 {
                                     m_responseBuffer = std::move(buffer);
+                                    // See the String case: keep StatusText() consistent with the
+                                    // status code that this backend normalizes to Ok on success.
                                     m_statusCode = UrlStatusCode::Ok;
+                                    m_statusText.clear();
                                 });
                         }
                         default:


### PR DESCRIPTION
## Summary

Exposes the HTTP **status reason phrase** via a new `UrlRequest::StatusText()`.

`UrlLib` previously surfaced only the numeric status code. `StatusText()` returns:
- the **reason phrase carried on the wire** where the transport provides one (HTTP/1.x status line), and
- a canonical **code→text fallback table** for HTTP/2+ (whose status line omits the phrase) and for backends that don't surface it.

## Backends

| Platform | Source of reason phrase |
|---|---|
| Win32 / UWP | `HttpResponseMessage.ReasonPhrase()` |
| Unix (libcurl) | parsed from the status line in the header callback (resets per redirect hop) |
| Apple | table fallback — `NSHTTPURLResponse` exposes no raw phrase |
| Android | table fallback — the `HttpURLConnection` wrapper has no `getResponseMessage()` yet |

Apple/Android still return correct text via the table; wiring their native phrase can be a follow-up (Android needs an `AndroidExtensions` `getResponseMessage` wrapper).

## Implementation

- `Include/UrlLib/UrlLib.h`: declare `std::string_view StatusText() const`.
- `Source/UrlRequest_Base.h`: `m_statusText` member, `ReasonPhraseForStatusCode()` table, `StatusText()` (wire phrase else table), reset in `ResetForOpen()`.
- `Source/UrlRequest_Shared.h`: pimpl delegation.
- Windows/Unix backends populate `m_statusText` from the wire.

## Motivation

In practice, `statusText` is consumed purely to decorate error messages — Babylon.js interpolates `status + " " + statusText` in the scene/file/texture loaders, `assetsManager`, `fileTools`, the native cube-texture path, etc., and nothing branches on its value. So the concrete win here is that native asset-load failures read `404 Not Found` instead of `404 undefined` / `404 ` — not browser-accurate `statusText` semantics (real browsers return `""` over HTTP/2, which is most CDN traffic). The code→text table is deliberately chosen to match how the value is actually used.

This also lets `BabylonJS/JsRuntimeHost`'s Fetch polyfill drop its private status-text table, and gives `XMLHttpRequest` a populated `statusText`. See JsRuntimeHost#193.
