### PR TITLE
Add GitHub Actions CI (Win32, macOS, Linux)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,42 @@
+name: Build Linux
+
+on:
+  workflow_call:
+    inputs:
+      cc:
+        required: false
+        type: string
+        default: gcc
+      cxx:
+        required: false
+        type: string
+        default: g++
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CC: ${{ inputs.cc }}
+      CXX: ${{ inputs.cxx }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev ninja-build clang
+
+      - name: Configure CMake
+        run: |
+          cmake -B Build/ubuntu -G Ninja \
+            -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+            -D CMAKE_C_COMPILER=${{ inputs.cc }} \
+            -D CMAKE_CXX_COMPILER=${{ inputs.cxx }}
+
+      - name: Build
+        run: ninja -C Build/ubuntu
+
+      - name: Run Tests
+        working-directory: Build/ubuntu/Tests
+        run: ./UrlLibTests

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,32 @@
+name: Build macOS
+
+on:
+  workflow_call:
+    inputs:
+      xcode-version:
+        required: true
+        type: string
+      runs-on:
+        required: false
+        type: string
+        default: macos-latest
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode ${{ inputs.xcode-version }}
+        run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-version }}.app/Contents/Developer
+
+      - name: Configure CMake
+        run: cmake -B Build/macOS -G Xcode
+
+      - name: Build
+        run: cmake --build Build/macOS --target UrlLibTests --config RelWithDebInfo
+
+      - name: Run Tests
+        working-directory: Build/macOS/Tests/RelWithDebInfo
+        run: ./UrlLibTests

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Enable Crash Dumps
         shell: cmd
         run: |
+          rem WER does not reliably create a custom DumpFolder at crash time; make sure it
+          rem exists before the registry points at it.
+          if not exist "%RUNNER_TEMP%\Dumps" mkdir "%RUNNER_TEMP%\Dumps"
           reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /f
           reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /v DumpType /t REG_DWORD /d 2 /f
           reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /v DumpCount /t REG_DWORD /d 1 /f

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -1,0 +1,49 @@
+name: Build Win32
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: windows-2022
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure CMake
+        run: cmake -B Build/Win32 -A ${{ inputs.platform }}
+
+      - name: Build Solution
+        run: cmake --build Build/Win32 --config RelWithDebInfo -- /m
+
+      - name: Enable Crash Dumps
+        shell: cmd
+        run: |
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /f
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /v DumpType /t REG_DWORD /d 2 /f
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /v DumpCount /t REG_DWORD /d 1 /f
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UrlLibTests.exe" /v DumpFolder /t REG_SZ /d "%RUNNER_TEMP%\Dumps" /f
+
+      - name: Run Tests
+        shell: cmd
+        working-directory: Build/Win32/Tests/RelWithDebInfo
+        run: UrlLibTests.exe
+
+      - name: Stage Test App for Crash Dumps
+        if: failure()
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\Dumps" | Out-Null
+          Copy-Item -Path "Build\Win32\Tests\RelWithDebInfo\UrlLibTests.*" -Destination "$env:RUNNER_TEMP\Dumps\" -ErrorAction SilentlyContinue
+
+      - name: Upload Crash Dumps
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.platform }}-crash-dumps
+          path: ${{ runner.temp }}/Dumps/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── Win32 ─────────────────────────────────────────────────────
+  Win32_x64:
+    uses: ./.github/workflows/build-win32.yml
+    with:
+      platform: x64
+
+  # ── macOS ─────────────────────────────────────────────────────
+  macOS_Xcode164:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      xcode-version: '16.4'
+      runs-on: macos-latest
+
+  # ── Linux ─────────────────────────────────────────────────────
+  Ubuntu_gcc:
+    uses: ./.github/workflows/build-linux.yml
+
+  Ubuntu_clang:
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      cc: clang
+      cxx: clang++


### PR DESCRIPTION
Adds GitHub Actions CI to UrlLib (the repo previously had none), split out of #31 so the infrastructure can be reviewed on its own merits.

> ✅ **Standalone as of #33.** The `Run Tests` steps execute the `UrlLibTests` target that landed on `main` via #33 (which superseded the now-closed #31), so this PR no longer depends on anything unmerged.

### Structure

Mirrors the JsRuntimeHost / BabylonNative workflow conventions so the matrix can grow the same way those repos' did:

- `ci.yml` orchestrator (`push`/`pull_request` on `main`) calling reusable per-platform `workflow_call` files, with the family's job naming and section ordering (Win32 → macOS → Linux).
- `build-win32.yml` — `windows-2022` (the explicit VS2022-generator pin both sibling repos adopted after the runner-image change), `-A` platform input, `RelWithDebInfo` with `/m`, crash-dump registry staging + dump artifact upload on failure, runs `UrlLibTests.exe` directly.
- `build-macos.yml` — pinned `xcode-select` (16.4 / `macos-latest`, the pairing JsRuntimeHost runs), `-G Xcode`, runs the binary from `Tests/RelWithDebInfo`.
- `build-linux.yml` — Ninja with explicit compiler inputs; `Ubuntu_gcc` and `Ubuntu_clang` jobs; installs `libcurl4-openssl-dev`.
- `actions/checkout@v5`, `timeout-minutes: 15`, `Build/<platform>` dirs throughout.

Starter matrix is `Win32_x64` + `macOS_Xcode164` + `Ubuntu_gcc`/`Ubuntu_clang`; Win32_x86, UWP, and Android jobs are three-line additions in `ci.yml` when wanted.

### Verification

All four jobs green against #31's branch on the fork mirror (rebeckerspecialties/UrlLib#1): https://github.com/rebeckerspecialties/UrlLib/actions/runs/27312871316 — including the curl error-path assertions on Linux and the Windows run (1 real pass + 5 explicit `GTEST_SKIP`s documenting that the Windows backend doesn't populate transport-error detail yet).

---
*[Edited by Copilot on behalf of @bghgary] Updated the stale #31 dependency note — the `UrlLibTests` target is already on `main` via #33.*
