### PR TITLE
Enable HTTP/2 and HTTP/3 across the NSURLSession, libcurl, and WinRT backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Platform support: the Apple (`NSURLSession`) and Linux (`libcurl`) backends popu
 these accessors today; the Windows and Android backends currently always report
 empty/zero (contributions welcome — the plumbing in `UrlRequest_Base.h` is shared).
 
+## HTTP versions
+
+`UrlRequest` opts each backend into the newest HTTP version the platform stack supports,
+negotiating downward automatically — application code never has to care, and plain
+`http://` / `file://` requests are unaffected.
+
+| Platform | Backend | HTTP/2 | HTTP/3 (QUIC) |
+|---|---|---|---|
+| macOS / iOS | `NSURLSession` | automatic (ALPN) since macOS 10.11 / iOS 9 | attempted per request via `assumesHTTP3Capable` on macOS 11.3+ / iOS 14.5+; races QUIC vs TCP with fallback |
+| Linux | libcurl | `CURL_HTTP_VERSION_2TLS` when the runtime curl has nghttp2 (all mainstream distros) | `CURL_HTTP_VERSION_3` (with fallback) when the runtime curl ≥ 8.0 reports `CURL_VERSION_HTTP3` (e.g. Fedora today; other distros as they enable it) |
+| Windows (Win32 + UWP) | `Windows.Web.Http` | `HttpBaseProtocolFilter.MaxVersion = Http20`, negotiated via ALPN; requires Windows 10 1607+ | not exposed by `Windows.Web.Http` (`HttpVersion` caps at `Http20`); planned via a WinHTTP-based backend, which no-ops the h3 flag before Windows 11 and negotiates down |
+| Android | `java.net.HttpURLConnection` | not supported by the platform stack (HTTP/1.1 only) | planned via embedded Cronet (h2 + h3 + Brotli); Quest 1 (Android 10) and Pico 4 (Android 10) clear Cronet's Android 8 minimum |
+
+The Linux detection is at runtime, so the same binary lights up h3 when the system curl
+gains it. No UrlLib build options are required.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on our code of conduct, and 

--- a/Source/UrlRequest_Apple.mm
+++ b/Source/UrlRequest_Apple.mm
@@ -132,6 +132,15 @@ namespace UrlLib
                 mutableRequest.HTTPBody = requestBodyData;
             }
 
+            if (@available(macOS 11.3, iOS 14.5, *))
+            {
+                // Let NSURLSession attempt HTTP/3 (QUIC) for this request directly instead of
+                // waiting to learn h3 support from a prior response's Alt-Svc header; the stack
+                // races QUIC against TCP and falls back to h2/h1.1 when the server lacks h3.
+                // HTTP/2 has been automatic via ALPN since iOS 9 / macOS 10.11.
+                mutableRequest.assumesHTTP3Capable = YES;
+            }
+
             request = [mutableRequest copy];
 
             __block arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};

--- a/Source/UrlRequest_Apple.mm
+++ b/Source/UrlRequest_Apple.mm
@@ -132,13 +132,26 @@ namespace UrlLib
                 mutableRequest.HTTPBody = requestBodyData;
             }
 
-            if (@available(macOS 11.3, iOS 14.5, *))
+            // HTTP/3 (QUIC) is TLS-only, so restrict the opt-in to https:// (app:// has been
+            // rewritten to file:// by now, and file:///http:// gain nothing). HTTP/2 has been
+            // automatic via ALPN since iOS 9 / macOS 10.11 and needs no opt-in.
+            //
+            // The #if guards compilation on the *SDK* version: assumesHTTP3Capable was added in
+            // the macOS 11.3 / iOS 14.5 SDKs, and @available only gates the runtime deployment
+            // target -- referencing the property against an older SDK is a hard compile error.
+            // Together: #if keeps it out of older-SDK builds, @available keeps it off older OSes.
+            if ([m_url.scheme caseInsensitiveCompare:@"https"] == NSOrderedSame)
             {
-                // Let NSURLSession attempt HTTP/3 (QUIC) for this request directly instead of
-                // waiting to learn h3 support from a prior response's Alt-Svc header; the stack
-                // races QUIC against TCP and falls back to h2/h1.1 when the server lacks h3.
-                // HTTP/2 has been automatic via ALPN since iOS 9 / macOS 10.11.
-                mutableRequest.assumesHTTP3Capable = YES;
+#if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 110300) || \
+    (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500)
+                if (@available(macOS 11.3, iOS 14.5, *))
+                {
+                    // Attempt h3 for this request directly rather than waiting to learn support
+                    // from a prior response's Alt-Svc header; the stack races QUIC against TCP
+                    // and falls back to h2/h1.1 when the server lacks h3.
+                    mutableRequest.assumesHTTP3Capable = YES;
+                }
+#endif
             }
 
             request = [mutableRequest copy];

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -150,24 +150,41 @@ namespace UrlLib
                 // the transfer; see the error handling in PerformAsync.
                 curl_check(curl_easy_setopt(m_curl, CURLOPT_ERRORBUFFER, m_curlErrorBuffer.data()));
 
-                // Prefer the newest HTTP version this libcurl build supports, detected at
-                // runtime so the same binary upgrades transparently with the system curl.
-                // These options only affect https:// transfers (plain http:// and file://
-                // stay HTTP/1.1), and both negotiate downward when the server lacks support.
-                const auto* versionInfo = curl_version_info(CURLVERSION_NOW);
-#if defined(CURL_VERSION_HTTP3)
-                // HTTP/3 with fallback. Gated on runtime curl >= 8.0.0: earlier curls treat
-                // CURL_HTTP_VERSION_3 as h3-or-fail instead of h3-with-fallback.
-                if ((versionInfo->features & CURL_VERSION_HTTP3) && versionInfo->version_num >= 0x080000)
+                // HTTP/2 and HTTP/3 are TLS-only, so only opt https:// transfers into a newer
+                // version; file://, app:// (rewritten to file above), and plain http:// keep
+                // libcurl's default. The version this build supports is detected at runtime so
+                // the same binary upgrades transparently with the system curl, and every value
+                // negotiates downward when the server or transport lacks support.
+                //
+                // The compile-time guards below key off LIBCURL_VERSION_NUM (a real macro from
+                // curlver.h) rather than the CURL_HTTP_VERSION_* constants: those are enum
+                // values, invisible to the preprocessor, so `#if defined(CURL_HTTP_VERSION_3)`
+                // would silently always be false. CURL_HTTP_VERSION_2TLS arrived in 7.47.0 and
+                // CURL_HTTP_VERSION_3 in 7.66.0.
+                if (scheme != nullptr && std::strcmp(scheme, "https") == 0)
                 {
-                    curl_check(curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3));
-                }
-                else
+                    const auto* versionInfo = curl_version_info(CURLVERSION_NOW);
+                    long httpVersion = CURL_HTTP_VERSION_NONE;
+#if LIBCURL_VERSION_NUM >= 0x074200 /* 7.66.0 */
+                    // HTTP/3 with fallback. The runtime >= 8.0.0 gate matters because earlier
+                    // curls treat CURL_HTTP_VERSION_3 as h3-or-fail instead of h3-with-fallback.
+                    if ((versionInfo->features & CURL_VERSION_HTTP3) && versionInfo->version_num >= 0x080000)
+                    {
+                        httpVersion = CURL_HTTP_VERSION_3;
+                    }
+                    else
 #endif
-                if (versionInfo->features & CURL_VERSION_HTTP2)
-                {
-                    // HTTP/2 over TLS via ALPN, HTTP/1.1 otherwise.
-                    curl_check(curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS));
+#if LIBCURL_VERSION_NUM >= 0x072F00 /* 7.47.0 */
+                    if (versionInfo->features & CURL_VERSION_HTTP2)
+                    {
+                        // HTTP/2 over TLS via ALPN, HTTP/1.1 otherwise.
+                        httpVersion = CURL_HTTP_VERSION_2TLS;
+                    }
+#endif
+                    if (httpVersion != CURL_HTTP_VERSION_NONE)
+                    {
+                        curl_check(curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, httpVersion));
+                    }
                 }
             }
         }

--- a/Source/UrlRequest_Unix.cpp
+++ b/Source/UrlRequest_Unix.cpp
@@ -149,6 +149,26 @@ namespace UrlLib
                 // Request-specific failure detail (host/port/path specifics) lands here during
                 // the transfer; see the error handling in PerformAsync.
                 curl_check(curl_easy_setopt(m_curl, CURLOPT_ERRORBUFFER, m_curlErrorBuffer.data()));
+
+                // Prefer the newest HTTP version this libcurl build supports, detected at
+                // runtime so the same binary upgrades transparently with the system curl.
+                // These options only affect https:// transfers (plain http:// and file://
+                // stay HTTP/1.1), and both negotiate downward when the server lacks support.
+                const auto* versionInfo = curl_version_info(CURLVERSION_NOW);
+#if defined(CURL_VERSION_HTTP3)
+                // HTTP/3 with fallback. Gated on runtime curl >= 8.0.0: earlier curls treat
+                // CURL_HTTP_VERSION_3 as h3-or-fail instead of h3-with-fallback.
+                if ((versionInfo->features & CURL_VERSION_HTTP3) && versionInfo->version_num >= 0x080000)
+                {
+                    curl_check(curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3));
+                }
+                else
+#endif
+                if (versionInfo->features & CURL_VERSION_HTTP2)
+                {
+                    // HTTP/2 over TLS via ALPN, HTTP/1.1 otherwise.
+                    curl_check(curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS));
+                }
             }
         }
 

--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -7,6 +7,7 @@
 #include <robuffer.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.h>
+#include <winrt/Windows.Web.Http.Filters.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Web.Http.Headers.h>
@@ -95,7 +96,13 @@ namespace UrlLib
                 );
             }
 
-            Web::Http::HttpClient client;
+            // Explicitly allow HTTP/2 (negotiated via ALPN for https, supported since
+            // Windows 10 1607) rather than relying on the OS-build default for MaxVersion.
+            // HTTP/3 has no knob in Windows.Web.Http -- HttpVersion caps at Http20; it
+            // arrives with a WinHTTP-based backend (see the Readme's HTTP versions matrix).
+            Web::Http::Filters::HttpBaseProtocolFilter filter;
+            filter.MaxVersion(Web::Http::HttpVersion::Http20);
+            Web::Http::HttpClient client{filter};
             return arcana::create_task<std::exception_ptr>(client.SendRequestAsync(requestMessage))
                 .then(arcana::inline_scheduler, m_cancellationSource, [this](Web::Http::HttpResponseMessage responseMessage)
                 {


### PR DESCRIPTION
Opts every backend into the newest HTTP version its platform stack supports, negotiating downward automatically. Only `https://` transfers are affected — `http://` and `file://` stay HTTP/1.1 — and every option falls back cleanly, so behavior against servers without h2/h3 is unchanged. **Zero binary-size cost**: no vendored network stacks; everything here is runtime detection or a request-level flag on the OS stack (a hard constraint for Babylon Native, which links UrlLib into shipped app binaries).

### Per-platform support matrix

| Platform | Backend | HTTP/2 | HTTP/3 (QUIC) | This PR |
|---|---|---|---|---|
| macOS / iOS | `NSURLSession` | automatic (ALPN) since macOS 10.11 / iOS 9 | OS-supported; requires opt-in per request | ✅ sets `assumesHTTP3Capable` on macOS 11.3+ / iOS 14.5+ (`@available`-guarded) — races QUIC vs TCP with fallback, so first requests can use h3 without prior Alt-Svc discovery |
| Linux | libcurl | ALPN h2 when built with nghttp2 (all mainstream distros) | needs an h3-enabled curl build (Fedora ships one today; Ubuntu not yet) | ✅ runtime `curl_version_info` detection: `CURL_HTTP_VERSION_3` (with fallback, gated on curl ≥ 8.0 where VERSION_3 stopped meaning h3-or-fail) when `CURL_VERSION_HTTP3` is present, else `CURL_HTTP_VERSION_2TLS`. The same binary lights up h3 as distros enable it |
| Windows Win32 + UWP | `Windows.Web.Http` | ALPN h2, **Windows 10 1607+** | OS has it (Windows 11 WinHTTP/msquic) but `Windows.Web.Http` exposes no knob — `HttpVersion` caps at `Http20` | ✅ pins `HttpBaseProtocolFilter.MaxVersion = Http20` explicitly instead of trusting OS-build defaults; h3 documented as arriving with a WinHTTP-based backend (flag no-ops pre-Win11 and negotiates down, so Win10 1607 stays the supported floor) |
| Android | `java.net.HttpURLConnection` | ❌ platform stack is HTTP/1.1-only | ❌ | 📋 documented follow-up: embedded Cronet (h2 + h3 + Brotli). Devices without Google Play Services (Quest, Pico) need the embedded flavor; Quest 1 and Pico 4 both run Android 10 (API 29), clearing Cronet's Android 8 (API 26) minimum |

### Binary-size guidance for the two follow-ups (kept out of this PR deliberately)

- **Vendored curl on Linux** (only needed if guaranteed-h3 matters before distros enable it): build with `CMAKE_BUILD_TYPE=MinSizeRel` + `CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` and `HTTP_ONLY=ON` (strips FTP/IMAP/SMTP/RTSP/etc.), no libpsl/brotli/zstd — an -Os/LTO curl+nghttp2 lands well under 1 MB; the QUIC TLS dependency is the real weight, which is why runtime detection is this PR's default.
- **Embedded Cronet on Android**: ~4–8 MB per ABI even with LTO, and without GMS auto-update the app owns shipping network-stack security patches — both argue for keeping `HttpURLConnection` as a permanent runtime fallback rather than making Cronet load-bearing.

### Verification

- macOS: full suite green locally (8/8) with the h3 flag active on every network test; curl TU compiles clean under `-Wall -Wextra`.
- Linux (gcc + clang) and Win32 (the `HttpBaseProtocolFilter` change): green on the fork CI runner — rebeckerspecialties/UrlLib#3.
- The offline suite is unaffected by design (plain-http loopback and `file://` never negotiate h2/h3), which is exactly the no-behavior-change property claimed above. Protocol *observability* (a `NegotiatedProtocol()` accessor feeding `PerformanceResourceTiming.nextHopProtocol` in JsRuntimeHost) is a named follow-up so this PR stays enablement-only.
