### PR TITLE
Win32: surface the real error when opening a URL fails

### DIFF
--- a/Source/UrlRequest_Win32.cpp
+++ b/Source/UrlRequest_Win32.cpp
@@ -40,13 +40,13 @@ namespace UrlLib
         }
         catch (const winrt::hresult_error& error)
         {
-            // Retain the default status code of 0 to indicate a client-side error, but
-            // capture the real WinRT error into the status text instead of discarding it,
-            // so the failure is diagnosable (e.g. surfaced via XMLHttpRequest.statusText).
-            std::ostringstream message;
-            message << winrt::to_string(error.message()) << " (HRESULT 0x" << std::hex << std::uppercase
-                    << static_cast<uint32_t>(error.code()) << ")";
-            m_statusText = message.str();
+            // Retain the default status code of 0 to indicate a client-side (transport)
+            // error, but record the WinRT failure via SetError -- consistent with the
+            // curl/NSURL backends -- so it is diagnosable through
+            // ErrorString()/ErrorSymbol()/ErrorCode() instead of being silently discarded.
+            std::ostringstream symbol;
+            symbol << "0x" << std::hex << std::uppercase << static_cast<uint32_t>(error.code());
+            SetError("winrt", symbol.str(), static_cast<int32_t>(error.code()), winrt::to_string(error.message()));
             return arcana::task_from_result<std::exception_ptr>();
         }
     }

--- a/Source/UrlRequest_Win32.cpp
+++ b/Source/UrlRequest_Win32.cpp
@@ -38,9 +38,15 @@ namespace UrlLib
                 return LoadHttpAsync();
             }
         }
-        catch (winrt::hresult_error)
+        catch (const winrt::hresult_error& error)
         {
-            // Catch WinRT exceptions, but retain the default status code of 0 to indicate a client side error.
+            // Retain the default status code of 0 to indicate a client-side error, but
+            // capture the real WinRT error into the status text instead of discarding it,
+            // so the failure is diagnosable (e.g. surfaced via XMLHttpRequest.statusText).
+            std::ostringstream message;
+            message << winrt::to_string(error.message()) << " (HRESULT 0x" << std::hex << std::uppercase
+                    << static_cast<uint32_t>(error.code()) << ")";
+            m_statusText = message.str();
             return arcana::task_from_result<std::exception_ptr>();
         }
     }

--- a/Source/UrlRequest_Windows_Shared.h
+++ b/Source/UrlRequest_Windows_Shared.h
@@ -1,5 +1,6 @@
 #include "UrlRequest_Base.h"
 
+#include <sstream>
 #include <Unknwn.h>
 #include <PathCch.h>
 #include <arcana/threading/task_conversions.h>
@@ -53,7 +54,21 @@ namespace UrlLib
 #endif
 
             m_method = method;
-            m_uri = Foundation::Uri{winrt::to_hstring(url)};
+            try
+            {
+                m_uri = Foundation::Uri{winrt::to_hstring(url)};
+            }
+            catch (const winrt::hresult_error& error)
+            {
+                // Foundation::Uri rejects some inputs (e.g. malformed or unsupported URLs)
+                // by throwing a WinRT hresult_error, which is not a std::exception. Rethrow
+                // as std::runtime_error so callers (e.g. the XMLHttpRequest polyfill) surface
+                // the real reason instead of a generic "Unknown error opening URL".
+                std::ostringstream message;
+                message << "Unable to open URL '" << url << "': " << winrt::to_string(error.message())
+                        << " (HRESULT 0x" << std::hex << std::uppercase << static_cast<uint32_t>(error.code()) << ")";
+                throw std::runtime_error{message.str()};
+            }
         }
 
         arcana::task<void, std::exception_ptr> SendAsync();


### PR DESCRIPTION
### Problem

`UrlRequest::Impl::Open` (Windows backend) constructs a WinRT `Foundation::Uri`:

```cpp
m_uri = Foundation::Uri{winrt::to_hstring(url)};
```

When the input is not a valid/supported URL, `Foundation::Uri` throws a **`winrt::hresult_error`**, which is **not** a `std::exception`. Downstream consumers such as the JsRuntimeHost `XMLHttpRequest` polyfill only catch `std::exception`, so the error falls through to a generic `catch (...)` and is reported as an opaque:

```
Unknown error opening URL
```

There is no message and no HRESULT, so these failures are impossible to triage from the JS side.

`SendAsync` (Win32) had the same problem in the other direction — it swallowed `winrt::hresult_error` entirely (`catch (winrt::hresult_error) { ... }`), discarding the message and HRESULT.

### Fix

- **`UrlRequest_Windows_Shared.h` (`Impl::Open`)** — wrap the `Foundation::Uri` construction in a `try/catch` that converts the `winrt::hresult_error` into a `std::runtime_error` including the offending URL, the system message, and the HRESULT. This routes through the polyfill's existing `catch (const std::exception&)` so JS reports the real reason.
- **`UrlRequest_Win32.cpp` (`SendAsync`)** — keep the status-0 (client-side error) contract, but record the WinRT message + HRESULT into `StatusText` instead of discarding it, so send-time failures are diagnosable via `xhr.statusText`.

No behavioral change on the success path; this only improves error reporting.

### Real-world impact

While triaging a batch of Babylon Native asset-loading failures that all reported the useless `Unknown error opening URL`, this change immediately surfaced the true cause. For example:

```
Unable to open URL 'import createSpzModule from 'https://unpkg.com/@adobe/spz@0.2.2/dist/spz.js';
': The parameter is incorrect. (HRESULT 0x80070057)
```

The "URL" is actually a JavaScript dynamic-`import` statement being passed to `XHR.open()` — an entirely different problem than a network/transport error, and one that was completely hidden before this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
