### PR TITLE
Add pluggable URL scheme resolver (e.g. blob:) to UrlRequest

### DIFF
--- a/Include/UrlLib/UrlLib.h
+++ b/Include/UrlLib/UrlLib.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <arcana/threading/task.h>
 #include <unordered_map>
+#include <vector>
 
 namespace UrlLib
 {
@@ -28,6 +30,21 @@ namespace UrlLib
         Buffer,
     };
 
+    // Result returned by a custom URL scheme resolver (see UrlRequest::RegisterSchemeResolver).
+    // When `handled` is false the URL had no live entry (e.g. a revoked blob: URL) and the request
+    // surfaces as a network error (status stays 0/None), mirroring the transport-failure contract.
+    struct UrlSchemeResolverResult
+    {
+        bool handled{false};
+        UrlStatusCode statusCode{UrlStatusCode::None};
+        std::string statusText{};
+        std::string contentType{};
+        std::shared_ptr<const std::vector<std::byte>> body{};
+    };
+
+    // Resolves a URL of a registered non-transport scheme (e.g. "blob") to an in-memory response.
+    using UrlSchemeResolver = std::function<UrlSchemeResolverResult(const std::string& url)>;
+
     class UrlRequest final
     {
     public:
@@ -45,6 +62,14 @@ namespace UrlLib
         void Abort();
 
         void Open(UrlMethod method, const std::string& url);
+
+        // Registers (or, with a null resolver, clears) a resolver for a non-transport URL scheme
+        // such as "blob". Registration is process-global. When a UrlRequest is opened with a URL
+        // whose scheme has a registered resolver, the platform transport is bypassed and the
+        // resolver supplies the response at SendAsync() time, so every consumer (fetch,
+        // XMLHttpRequest, image / video src, texture loaders, ...) resolves such URLs uniformly
+        // through UrlRequest instead of each carrying its own branch.
+        static void RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver);
 
         UrlResponseType ResponseType() const;
 

--- a/Include/UrlLib/UrlLib.h
+++ b/Include/UrlLib/UrlLib.h
@@ -63,13 +63,26 @@ namespace UrlLib
 
         void Open(UrlMethod method, const std::string& url);
 
-        // Registers (or, with a null resolver, clears) a resolver for a non-transport URL scheme
-        // such as "blob". Registration is process-global. When a UrlRequest is opened with a URL
-        // whose scheme has a registered resolver, the platform transport is bypassed and the
-        // resolver supplies the response at SendAsync() time, so every consumer (fetch,
-        // XMLHttpRequest, image / video src, texture loaders, ...) resolves such URLs uniformly
-        // through UrlRequest instead of each carrying its own branch.
+        // Registers a resolver for a non-transport URL scheme such as "blob". Registration is
+        // process-global. When a UrlRequest is opened with a URL whose scheme has a registered
+        // resolver, the platform transport is bypassed and the resolver supplies the response at
+        // SendAsync() time, so every consumer (fetch, XMLHttpRequest, image / video src, texture
+        // loaders, ...) resolves such URLs uniformly through UrlRequest instead of each carrying
+        // its own branch.
+        //
+        // A resolver that reports the URL as not handled -- or that throws -- surfaces as a
+        // transport-style failure (status stays None, with an error symbol recorded); an exception
+        // never escapes SendAsync().
+        //
+        // Throws std::invalid_argument if `scheme` is empty or `resolver` is null. Removal is the
+        // explicit UnregisterSchemeResolver call rather than registering an empty std::function, so
+        // a moved-from or default-constructed resolver cannot silently unregister a scheme.
         static void RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver);
+
+        // Removes the resolver registered for `scheme`, if any. Unknown schemes are ignored.
+        // In-flight requests already diverted to that resolver are unaffected: each request holds
+        // its own reference to the resolver from the time it was opened.
+        static void UnregisterSchemeResolver(std::string scheme);
 
         UrlResponseType ResponseType() const;
 

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -30,19 +31,36 @@ namespace UrlLib
         // BeginSchemeResolution is called from Open() to divert a matching URL; ResolveScheme is
         // called from SendAsync() so revoke-after-open is honored; ResolvedResponseBuffer backs
         // ResponseBuffer() for the Buffer response type.
+        //
+        // A null resolver is rejected rather than treated as an implicit removal: a resolver can
+        // capture state that must outlive registration, so silently unregistering on a moved-from
+        // or default-constructed std::function would be an easy mistake to miss. Removal is the
+        // explicit UnregisterSchemeResolver call.
         static void RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver)
+        {
+            if (!resolver)
+            {
+                throw std::invalid_argument{"RegisterSchemeResolver: resolver must not be null (use UnregisterSchemeResolver to remove a scheme)"};
+            }
+
+            ToLower(scheme);
+            if (scheme.empty())
+            {
+                throw std::invalid_argument{"RegisterSchemeResolver: scheme must not be empty"};
+            }
+
+            auto& registry = Registry();
+            const std::lock_guard<std::mutex> lock{registry.mutex};
+            registry.resolvers[std::move(scheme)] = std::move(resolver);
+        }
+
+        // Removes the resolver registered for `scheme`, if any. Unknown schemes are ignored.
+        static void UnregisterSchemeResolver(std::string scheme)
         {
             ToLower(scheme);
             auto& registry = Registry();
             const std::lock_guard<std::mutex> lock{registry.mutex};
-            if (resolver)
-            {
-                registry.resolvers[std::move(scheme)] = std::move(resolver);
-            }
-            else
-            {
-                registry.resolvers.erase(scheme);
-            }
+            registry.resolvers.erase(scheme);
         }
 
         // Returns true (and defers the actual work to ResolveScheme()) when `url`'s scheme has a
@@ -80,12 +98,12 @@ namespace UrlLib
         }
 
         // Invokes the registered resolver and populates the response state. A resolver that reports
-        // the URL as not handled (e.g. a revoked blob: URL) leaves the status at 0 (None) and
-        // records a transport-style error, mirroring how a genuine network failure surfaces.
-        // The pending resolver is consumed here so a second SendAsync() on the same request does not
-        // re-run the resolver (which could re-trigger side effects or clobber the response); the
-        // resolved response state is retained and IsSchemeResolution() stays true so ResponseBuffer()
-        // keeps serving the resolved bytes.
+        // the URL as not handled (e.g. a revoked blob: URL) -- or that throws -- leaves the status at
+        // 0 (None) and records a transport-style error, mirroring how a genuine network failure
+        // surfaces. The pending resolver is consumed here so a second SendAsync() on the same request
+        // does not re-run the resolver (which could re-trigger side effects or clobber the response);
+        // the resolved response state is retained and IsSchemeResolution() stays true so
+        // ResponseBuffer() keeps serving the resolved bytes.
         void ResolveScheme()
         {
             if (!m_pendingResolver)
@@ -99,8 +117,26 @@ namespace UrlLib
             m_pendingResolver = nullptr;
             m_pendingResolverUrl.clear();
 
-            const UrlSchemeResolverResult result = resolver(url);
             m_responseUrl = url;
+
+            // A throwing resolver is contained here and reported through the same error surface as
+            // any other failure, so it cannot escape SendAsync() synchronously -- callers observe a
+            // failed request (status 0 + error) exactly as they would for a transport failure.
+            UrlSchemeResolverResult result{};
+            try
+            {
+                result = resolver(url);
+            }
+            catch (const std::exception& e)
+            {
+                SetError("urllib", "SchemeResolverThrew", 0, e.what());
+                return;
+            }
+            catch (...)
+            {
+                SetError("urllib", "SchemeResolverThrew", 0, "unknown exception");
+                return;
+            }
 
             if (!result.handled)
             {

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -82,6 +82,10 @@ namespace UrlLib
         // Invokes the registered resolver and populates the response state. A resolver that reports
         // the URL as not handled (e.g. a revoked blob: URL) leaves the status at 0 (None) and
         // records a transport-style error, mirroring how a genuine network failure surfaces.
+        // The pending resolver is consumed here so a second SendAsync() on the same request does not
+        // re-run the resolver (which could re-trigger side effects or clobber the response); the
+        // resolved response state is retained and IsSchemeResolution() stays true so ResponseBuffer()
+        // keeps serving the resolved bytes.
         void ResolveScheme()
         {
             if (!m_pendingResolver)
@@ -89,12 +93,18 @@ namespace UrlLib
                 return;
             }
 
-            const UrlSchemeResolverResult result = m_pendingResolver(m_pendingResolverUrl);
-            m_responseUrl = m_pendingResolverUrl;
+            // Move the resolver/url out and clear them before invoking, so this runs exactly once.
+            const UrlSchemeResolver resolver = std::move(m_pendingResolver);
+            const std::string url = std::move(m_pendingResolverUrl);
+            m_pendingResolver = nullptr;
+            m_pendingResolverUrl.clear();
+
+            const UrlSchemeResolverResult result = resolver(url);
+            m_responseUrl = url;
 
             if (!result.handled)
             {
-                SetError("urllib", "SchemeResolverNotFound", 0, "no live entry for '" + m_pendingResolverUrl + "'");
+                SetError("urllib", "SchemeResolverNotFound", 0, "no live entry for '" + url + "'");
                 return;
             }
 

--- a/Source/UrlRequest_Base.h
+++ b/Source/UrlRequest_Base.h
@@ -2,9 +2,12 @@
 
 #include <UrlLib/UrlLib.h>
 #include <arcana/threading/cancellation.h>
-#include <string>
 #include <cctype>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace UrlLib
 {
@@ -19,6 +22,106 @@ namespace UrlLib
         void Abort()
         {
             m_cancellationSource.cancel();
+        }
+
+        // ---- Custom scheme resolvers (e.g. blob:) ---------------------------------------------
+        // Resolution for registered schemes is handled entirely in the shared layer; the platform
+        // transport is never involved. RegisterSchemeResolver installs a process-global resolver;
+        // BeginSchemeResolution is called from Open() to divert a matching URL; ResolveScheme is
+        // called from SendAsync() so revoke-after-open is honored; ResolvedResponseBuffer backs
+        // ResponseBuffer() for the Buffer response type.
+        static void RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver)
+        {
+            ToLower(scheme);
+            auto& registry = Registry();
+            const std::lock_guard<std::mutex> lock{registry.mutex};
+            if (resolver)
+            {
+                registry.resolvers[std::move(scheme)] = std::move(resolver);
+            }
+            else
+            {
+                registry.resolvers.erase(scheme);
+            }
+        }
+
+        // Returns true (and defers the actual work to ResolveScheme()) when `url`'s scheme has a
+        // registered resolver, in which case the caller must not touch the platform transport.
+        bool BeginSchemeResolution(const std::string& url)
+        {
+            const std::string scheme = SchemeOf(url);
+            if (scheme.empty())
+            {
+                return false;
+            }
+
+            UrlSchemeResolver resolver{};
+            {
+                auto& registry = Registry();
+                const std::lock_guard<std::mutex> lock{registry.mutex};
+                const auto it = registry.resolvers.find(scheme);
+                if (it == registry.resolvers.end())
+                {
+                    return false;
+                }
+                resolver = it->second;
+            }
+
+            ResetForOpen();
+            m_pendingResolver = std::move(resolver);
+            m_pendingResolverUrl = url;
+            m_usingSchemeResolver = true;
+            return true;
+        }
+
+        bool IsSchemeResolution() const
+        {
+            return m_usingSchemeResolver;
+        }
+
+        // Invokes the registered resolver and populates the response state. A resolver that reports
+        // the URL as not handled (e.g. a revoked blob: URL) leaves the status at 0 (None) and
+        // records a transport-style error, mirroring how a genuine network failure surfaces.
+        void ResolveScheme()
+        {
+            if (!m_pendingResolver)
+            {
+                return;
+            }
+
+            const UrlSchemeResolverResult result = m_pendingResolver(m_pendingResolverUrl);
+            m_responseUrl = m_pendingResolverUrl;
+
+            if (!result.handled)
+            {
+                SetError("urllib", "SchemeResolverNotFound", 0, "no live entry for '" + m_pendingResolverUrl + "'");
+                return;
+            }
+
+            m_statusCode = result.statusCode;
+            if (!result.statusText.empty())
+            {
+                m_statusText = result.statusText;
+            }
+            if (!result.contentType.empty())
+            {
+                m_headers["content-type"] = result.contentType;
+            }
+
+            m_resolvedBuffer = result.body ? result.body : std::make_shared<const std::vector<std::byte>>();
+            if (m_responseType == UrlResponseType::String)
+            {
+                m_responseString.assign(reinterpret_cast<const char*>(m_resolvedBuffer->data()), m_resolvedBuffer->size());
+            }
+        }
+
+        gsl::span<const std::byte> ResolvedResponseBuffer() const
+        {
+            if (m_resolvedBuffer)
+            {
+                return {m_resolvedBuffer->data(), m_resolvedBuffer->size()};
+            }
+            return {};
         }
 
         void SetRequestBody(std::string requestBody) {
@@ -111,6 +214,20 @@ namespace UrlLib
         static void ToLower(std::string& s)
         {
             std::transform(s.cbegin(), s.cend(), s.begin(), [](auto c) { return static_cast<decltype(c)>(std::tolower(c)); });
+        }
+
+        // Returns the lower-cased scheme of `url` (the substring before the first ':'), or "" if
+        // the URL has no scheme.
+        static std::string SchemeOf(const std::string& url)
+        {
+            const auto pos = url.find(':');
+            if (pos == std::string::npos)
+            {
+                return {};
+            }
+            std::string scheme = url.substr(0, pos);
+            ToLower(scheme);
+            return scheme;
         }
 
         // Canonical HTTP reason phrases, used as a fallback when the transport does not carry
@@ -213,6 +330,10 @@ namespace UrlLib
             m_errorCode = 0;
             m_errorSymbol.clear();
             m_errorString.clear();
+            m_usingSchemeResolver = false;
+            m_pendingResolver = nullptr;
+            m_pendingResolverUrl.clear();
+            m_resolvedBuffer.reset();
         }
 
         arcana::cancellation_source m_cancellationSource{};
@@ -228,5 +349,28 @@ namespace UrlLib
         std::unordered_map<std::string, std::string> m_headers;
         std::string m_requestBody{};
         std::unordered_map<std::string, std::string> m_requestHeaders;
+
+        // Custom-scheme (e.g. blob:) resolution state. Populated by BeginSchemeResolution() /
+        // ResolveScheme(); inert for ordinary transport requests.
+        bool m_usingSchemeResolver{false};
+        UrlSchemeResolver m_pendingResolver{};
+        std::string m_pendingResolverUrl{};
+        std::shared_ptr<const std::vector<std::byte>> m_resolvedBuffer{};
+
+    private:
+        // Process-global registry of scheme resolvers, keyed by lower-cased scheme (no trailing
+        // ':'). Guarded by a mutex since RegisterSchemeResolver and request handling can run on
+        // different threads.
+        struct ResolverRegistry
+        {
+            std::mutex mutex;
+            std::unordered_map<std::string, UrlSchemeResolver> resolvers;
+        };
+
+        static ResolverRegistry& Registry()
+        {
+            static ResolverRegistry registry;
+            return registry;
+        }
     };
 }

--- a/Source/UrlRequest_Shared.h
+++ b/Source/UrlRequest_Shared.h
@@ -39,6 +39,11 @@ namespace UrlLib
         Impl::RegisterSchemeResolver(std::move(scheme), std::move(resolver));
     }
 
+    void UrlRequest::UnregisterSchemeResolver(std::string scheme)
+    {
+        Impl::UnregisterSchemeResolver(std::move(scheme));
+    }
+
     UrlResponseType UrlRequest::ResponseType() const
     {
         return m_impl->ResponseType();

--- a/Source/UrlRequest_Shared.h
+++ b/Source/UrlRequest_Shared.h
@@ -24,7 +24,19 @@ namespace UrlLib
 
     void UrlRequest::Open(UrlMethod method, const std::string& url)
     {
+        // Divert URLs whose scheme has a registered resolver (e.g. blob:) away from the platform
+        // transport; the resolver supplies the response in SendAsync().
+        if (m_impl->BeginSchemeResolution(url))
+        {
+            return;
+        }
+
         m_impl->Open(method, url);
+    }
+
+    void UrlRequest::RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver)
+    {
+        Impl::RegisterSchemeResolver(std::move(scheme), std::move(resolver));
     }
 
     UrlResponseType UrlRequest::ResponseType() const
@@ -59,6 +71,15 @@ namespace UrlLib
 
     arcana::task<void, std::exception_ptr> UrlRequest::SendAsync()
     {
+        // Registered-scheme requests (e.g. blob:) are served synchronously from the resolver; the
+        // resolution is deferred to here (rather than Open) so a blob: URL revoked between open()
+        // and send() is honored.
+        if (m_impl->IsSchemeResolution())
+        {
+            m_impl->ResolveScheme();
+            return arcana::task_from_result<std::exception_ptr>();
+        }
+
         return m_impl->SendAsync();
     }
 
@@ -99,6 +120,11 @@ namespace UrlLib
 
     gsl::span<const std::byte> UrlRequest::ResponseBuffer() const
     {
+        if (m_impl->IsSchemeResolution())
+        {
+            return m_impl->ResolvedResponseBuffer();
+        }
+
         return m_impl->ResponseBuffer();
     }
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_MakeAvailable(googletest)
 set_property(TARGET gtest PROPERTY FOLDER Dependencies)
 set_property(TARGET gtest_main PROPERTY FOLDER Dependencies)
 
-add_executable(UrlLibTests UrlRequestErrorReporting.cpp)
+add_executable(UrlLibTests UrlRequestErrorReporting.cpp SchemeResolver.cpp)
 
 target_link_libraries(UrlLibTests
     PRIVATE UrlLib

--- a/Tests/SchemeResolver.cpp
+++ b/Tests/SchemeResolver.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -55,7 +56,7 @@ TEST(SchemeResolver, HandledResolverPopulatesStringResponse)
     EXPECT_TRUE(request.ErrorSymbol().empty());
     EXPECT_TRUE(request.ErrorString().empty());
 
-    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
 }
 
 // A handled resolver serves the raw bytes for a Buffer response type.
@@ -80,7 +81,7 @@ TEST(SchemeResolver, HandledResolverPopulatesBufferResponse)
     ASSERT_EQ(buffer.size(), static_cast<size_t>(6));
     EXPECT_EQ(std::string(reinterpret_cast<const char*>(buffer.data()), buffer.size()), "world!");
 
-    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
 }
 
 // A resolver that reports handled == false (e.g. a revoked blob: URL) surfaces as a transport-style
@@ -102,7 +103,7 @@ TEST(SchemeResolver, NotHandledResolverSurfacesTransportError)
     EXPECT_FALSE(request.ErrorString().empty());
     EXPECT_TRUE(request.ResponseBuffer().empty());
 
-    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
 }
 
 // The resolver is consumed on the first SendAsync(); a second send does not re-run it (no repeated
@@ -129,5 +130,118 @@ TEST(SchemeResolver, ResolverRunsExactlyOncePerRequest)
     EXPECT_EQ(calls.load(), 1);
     EXPECT_EQ(request.ResponseBuffer().size(), static_cast<size_t>(4));
 
-    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
+}
+
+
+// A handled resolver that leaves statusText empty still reports the canonical reason phrase, since
+// StatusText() falls back to the code->phrase table for the resolver path exactly as it does for
+// the transport path (HTTP/2+ status lines carry no reason phrase).
+TEST(SchemeResolver, EmptyStatusTextFallsBackToReasonPhrase)
+{
+    const std::string scheme = "urllibtest-nostatustext";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        result.body = MakeBody("x");
+        return result; // statusText intentionally left empty
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    Send(request);
+
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::Ok);
+    EXPECT_EQ(request.StatusText(), "OK");
+
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
+}
+
+// A resolver that throws must not let the exception escape SendAsync(); it is reported through the
+// same transport-style error surface as a failed request.
+TEST(SchemeResolver, ThrowingResolverSurfacesTransportError)
+{
+    const std::string scheme = "urllibtest-throws";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) -> UrlLib::UrlSchemeResolverResult {
+        throw std::runtime_error{"resolver blew up"};
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    request.ResponseType(UrlLib::UrlResponseType::Buffer);
+    EXPECT_NO_THROW(Send(request));
+
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::None);
+    EXPECT_EQ(request.ErrorSymbol(), "SchemeResolverThrew");
+    EXPECT_NE(std::string{request.ErrorString()}.find("resolver blew up"), std::string::npos);
+    EXPECT_TRUE(request.ResponseBuffer().empty());
+
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
+}
+
+// Removal is explicit: a null resolver is rejected rather than silently unregistering the scheme.
+TEST(SchemeResolver, RegisteringNullResolverThrows)
+{
+    const std::string scheme = "urllibtest-null";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        return result;
+    });
+
+    EXPECT_THROW(UrlLib::UrlRequest::RegisterSchemeResolver(scheme, {}), std::invalid_argument);
+    EXPECT_THROW(UrlLib::UrlRequest::RegisterSchemeResolver("", [](const std::string&) {
+        return UrlLib::UrlSchemeResolverResult{};
+    }), std::invalid_argument);
+
+    // The rejected registration left the existing resolver in place.
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    Send(request);
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::Ok);
+
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
+}
+
+// After unregistering, the scheme is no longer diverted -- it falls through to the platform
+// transport, which fails on the unknown scheme rather than silently succeeding.
+TEST(SchemeResolver, UnregisterStopsDivertingScheme)
+{
+    const std::string scheme = "urllibtest-unregister";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        result.body = MakeBody("still here");
+        return result;
+    });
+
+    UrlLib::UrlRequest resolved;
+    resolved.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    Send(resolved);
+    EXPECT_EQ(resolved.StatusCode(), UrlLib::UrlStatusCode::Ok);
+
+    UrlLib::UrlRequest::UnregisterSchemeResolver(scheme);
+
+    // Unregistering an unknown scheme is a no-op, not an error.
+    EXPECT_NO_THROW(UrlLib::UrlRequest::UnregisterSchemeResolver(scheme));
+
+    UrlLib::UrlRequest afterUnregister;
+    bool opened = true;
+    try
+    {
+        afterUnregister.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    }
+    catch (...)
+    {
+        opened = false; // the transport rejected the unknown scheme outright
+    }
+
+    if (opened)
+    {
+        Send(afterUnregister);
+        EXPECT_NE(afterUnregister.StatusCode(), UrlLib::UrlStatusCode::Ok);
+    }
 }

--- a/Tests/SchemeResolver.cpp
+++ b/Tests/SchemeResolver.cpp
@@ -1,0 +1,133 @@
+#include <UrlLib/UrlLib.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+    std::shared_ptr<const std::vector<std::byte>> MakeBody(const std::string& text)
+    {
+        const auto* first = reinterpret_cast<const std::byte*>(text.data());
+        return std::make_shared<const std::vector<std::byte>>(first, first + text.size());
+    }
+
+    // Scheme resolution is synchronous: SendAsync() returns an already-completed task, so the inline
+    // continuation runs before this helper returns, leaving the request fully populated.
+    void Send(UrlLib::UrlRequest& request)
+    {
+        bool completed = false;
+        request.SendAsync().then(arcana::inline_scheduler, arcana::cancellation::none(),
+            [&completed](const arcana::expected<void, std::exception_ptr>&) { completed = true; });
+        ASSERT_TRUE(completed);
+    }
+}
+
+// A handled resolver populates status, status text, the content-type header and the response body.
+TEST(SchemeResolver, HandledResolverPopulatesStringResponse)
+{
+    const std::string scheme = "urllibtest-string";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        result.statusText = "OK";
+        result.contentType = "text/plain";
+        result.body = MakeBody("hello");
+        return result;
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    request.ResponseType(UrlLib::UrlResponseType::String);
+    Send(request);
+
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::Ok);
+    EXPECT_EQ(request.StatusText(), "OK");
+    EXPECT_EQ(request.ResponseString(), "hello");
+    EXPECT_EQ(request.ResponseUrl(), scheme + ":anything");
+    ASSERT_TRUE(request.GetResponseHeader("content-type").has_value());
+    EXPECT_EQ(*request.GetResponseHeader("content-type"), "text/plain");
+    EXPECT_TRUE(request.ErrorSymbol().empty());
+    EXPECT_TRUE(request.ErrorString().empty());
+
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+}
+
+// A handled resolver serves the raw bytes for a Buffer response type.
+TEST(SchemeResolver, HandledResolverPopulatesBufferResponse)
+{
+    const std::string scheme = "urllibtest-buffer";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        result.body = MakeBody("world!");
+        return result;
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    request.ResponseType(UrlLib::UrlResponseType::Buffer);
+    Send(request);
+
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::Ok);
+    const auto buffer = request.ResponseBuffer();
+    ASSERT_EQ(buffer.size(), static_cast<size_t>(6));
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buffer.data()), buffer.size()), "world!");
+
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+}
+
+// A resolver that reports handled == false (e.g. a revoked blob: URL) surfaces as a transport-style
+// error: status stays None (0), an error symbol is recorded, and the response buffer is empty.
+TEST(SchemeResolver, NotHandledResolverSurfacesTransportError)
+{
+    const std::string scheme = "urllibtest-missing";
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [](const std::string&) {
+        return UrlLib::UrlSchemeResolverResult{}; // handled == false
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":gone");
+    request.ResponseType(UrlLib::UrlResponseType::Buffer);
+    Send(request);
+
+    EXPECT_EQ(request.StatusCode(), UrlLib::UrlStatusCode::None);
+    EXPECT_EQ(request.ErrorSymbol(), "SchemeResolverNotFound");
+    EXPECT_FALSE(request.ErrorString().empty());
+    EXPECT_TRUE(request.ResponseBuffer().empty());
+
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+}
+
+// The resolver is consumed on the first SendAsync(); a second send does not re-run it (no repeated
+// side effects) while the already-resolved response remains available.
+TEST(SchemeResolver, ResolverRunsExactlyOncePerRequest)
+{
+    const std::string scheme = "urllibtest-once";
+    std::atomic<int> calls{0};
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, [&calls](const std::string&) {
+        ++calls;
+        UrlLib::UrlSchemeResolverResult result;
+        result.handled = true;
+        result.statusCode = UrlLib::UrlStatusCode::Ok;
+        result.body = MakeBody("once");
+        return result;
+    });
+
+    UrlLib::UrlRequest request;
+    request.Open(UrlLib::UrlMethod::Get, scheme + ":anything");
+    request.ResponseType(UrlLib::UrlResponseType::Buffer);
+    Send(request);
+    Send(request);
+
+    EXPECT_EQ(calls.load(), 1);
+    EXPECT_EQ(request.ResponseBuffer().size(), static_cast<size_t>(4));
+
+    UrlLib::UrlRequest::RegisterSchemeResolver(scheme, nullptr);
+}


### PR DESCRIPTION
## What

Adds a pluggable URL **scheme resolver** hook to `UrlRequest`, so a consumer can register a resolver for a non-transport URL scheme (e.g. `blob:`) and have every `UrlRequest`-based consumer (fetch, XMLHttpRequest, image/video `src`, texture loaders, ...) resolve such URLs uniformly through the transport layer instead of each carrying its own branch.

```cpp
UrlRequest::RegisterSchemeResolver("blob", [](const std::string& url) -> UrlSchemeResolverResult {
    // look up url in your store...
    return { /*handled*/ true, UrlStatusCode::Ok, "OK", contentType, bodyBytes };
});
```

## How

- New public API: `UrlRequest::RegisterSchemeResolver(std::string scheme, UrlSchemeResolver resolver)`, plus the `UrlSchemeResolverResult` struct and `UrlSchemeResolver` alias.
- When a `UrlRequest` is opened with a URL whose (lower-cased) scheme has a registered resolver, the platform transport is bypassed. Resolution is deferred to `SendAsync()` (rather than `Open()`) so a URL revoked between `open()` and `send()` is honored.
- A resolver that reports `handled == false` (e.g. a revoked `blob:` URL) leaves the status at `0`/`None` and records a transport-style error, mirroring how a genuine network failure surfaces.
- The registry is process-global and mutex-guarded. All logic lives in the shared `ImplBase` + the shared wrapper, so every platform backend (Win32/Unix/Apple/Android) inherits it with no per-platform changes.

## Testing

Builds clean with the Win32 backend (`UrlLib` and `UrlLibTests` targets). Downstream, this powers `URL.createObjectURL` `blob:` support in JsRuntimeHost — see BabylonJS/JsRuntimeHost#207 (tracked by BabylonJS/JsRuntimeHost#213), where all 216 unit tests pass with fetch/XMLHttpRequest resolving `blob:` through this hook.

> Opened because BabylonJS/UrlLib has Issues disabled; JsRuntimeHost#207 currently pins its UrlLib dependency at this fork commit and should be repointed once this lands.
